### PR TITLE
Implement responsive cart and fullscreen mobile menu

### DIFF
--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -17,6 +17,10 @@ const CartWrapper = styled.div`
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+
+  @media (max-width: 480px) {
+    padding: 1rem;
+  }
 `;
 
 const Item = styled.div`
@@ -39,6 +43,16 @@ const Item = styled.div`
     border: none;
     padding: 0.25rem 0.75rem;
     border-radius: 4px;
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+    text-align: center;
+
+    button {
+      width: 100%;
+      margin-top: 0.5rem;
+    }
   }
 `;
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -64,13 +64,16 @@ const Menu = styled(motion.ul)`
   gap: 1rem;
 
   @media (max-width: 768px) {
-    position: absolute;
-    top: 60px;
-    right: 0;
+    position: fixed;
+    inset: 0;
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
     background-color: var(--black);
     width: 100%;
-    padding: 1rem 0;
+    height: 100vh;
+    padding: 2rem;
+    z-index: 2000;
     transform-origin: top right;
   }
 
@@ -150,6 +153,10 @@ const Navbar = () => {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "auto";
+  }, [open]);
 
   return (
     <Nav


### PR DESCRIPTION
## Summary
- make mobile menu cover the whole page and disable body scroll when open
- improve CartPage layout on small screens

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845cb16dc1483248e50176da2322234