### PR TITLE
Improve gallery and events

### DIFF
--- a/src/components/EventiSection.jsx
+++ b/src/components/EventiSection.jsx
@@ -42,8 +42,8 @@ const Section = styled.section`
 
 const Cards = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
   margin-top: 2rem;
   padding-bottom: 2rem;
 `;
@@ -51,21 +51,39 @@ const Cards = styled.div`
 const Card = styled(motion.div)`
   background-color: #111;
   padding: 1rem;
-  border-radius: 4px;
+  border-radius: 8px;
   border: 1px solid var(--gray);
   display: flex;
   flex-direction: column;
-  align-items: center;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  text-align: left;
 
   img {
-    border-radius: 4px;
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+    border-radius: 6px;
     margin-bottom: 0.5rem;
   }
 
   h3 {
     color: var(--yellow);
+    margin-bottom: 0.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
   }
+
+  p {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin: 0.25rem 0;
+  }
+`;
+
+const CardContent = styled.div`
+  flex: 1;
 `;
 
 const Button = styled(motion.button)`
@@ -75,6 +93,7 @@ const Button = styled(motion.button)`
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;
+  align-self: flex-start;
 `;
 
 const EventiSection = () => {
@@ -96,11 +115,13 @@ const EventiSection = () => {
             whileHover={{ scale: 1.05, boxShadow: '0 0 8px var(--green)' }}
           >
             <img src={event.image} alt={event.place} />
-            <h3><FaMapMarkerAlt /> {event.place}</h3>
-            <p><FaCalendarAlt /> {event.date}</p>
-            <p><FaClock /> {event.time}</p>
-            <p>{event.description}</p>
-            <p><FaEuroSign /> {event.price}</p>
+            <CardContent>
+              <h3><FaMapMarkerAlt /> {event.place}</h3>
+              <p><FaCalendarAlt /> {event.date}</p>
+              <p><FaClock /> {event.time}</p>
+              <p>{event.description}</p>
+              <p><FaEuroSign /> {event.price}</p>
+            </CardContent>
             <Button
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}

--- a/src/components/GallerySection.jsx
+++ b/src/components/GallerySection.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { motion } from "framer-motion";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay, Pagination } from "swiper/modules";
+import { Autoplay, Pagination, Navigation } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/pagination";
 import img1 from "../assets/img/Copia di Testo del paragraf.png";
@@ -28,11 +28,25 @@ const StyledSwiper = styled(Swiper)`
     justify-content: center;
   }
 
+  .swiper-button-next,
+  .swiper-button-prev {
+    color: var(--yellow);
+  }
+`;
+
+const SlideContent = styled(motion.div)`
+  overflow: hidden;
+  border-radius: 6px;
+
   img {
     width: 100%;
-    height: 200px;
+    height: 250px;
     object-fit: cover;
-    border-radius: 4px;
+    transition: transform 0.4s;
+  }
+
+  &:hover img {
+    transform: scale(1.1);
   }
 `;
 
@@ -43,9 +57,11 @@ const GallerySection = () => (
     <div className="container">
       <h2>Gallery</h2>
       <StyledSwiper
-        modules={[Autoplay, Pagination]}
+        modules={[Autoplay, Pagination, Navigation]}
         autoplay={{ delay: 2500, disableOnInteraction: false }}
         pagination={{ clickable: true }}
+        navigation
+        loop
         spaceBetween={10}
         slidesPerView={1}
         breakpoints={{
@@ -55,7 +71,9 @@ const GallerySection = () => (
       >
         {images.map((img, idx) => (
           <SwiperSlide key={idx}>
-            <motion.img src={img} alt="gallery" whileHover={{ scale: 1.05 }} />
+            <SlideContent whileHover={{ scale: 1.02 }}>
+              <img src={img} alt="gallery" />
+            </SlideContent>
           </SwiperSlide>
         ))}
       </StyledSwiper>


### PR DESCRIPTION
## Summary
- tweak gallery carousel with navigation and new hover zoom
- adjust events cards layout for better readability

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845cde41de08324b67973294d7425ef