### PR TITLE
Improve shopping cart UX

### DIFF
--- a/src/components/CartContext.jsx
+++ b/src/components/CartContext.jsx
@@ -1,25 +1,66 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 
 const CartContext = createContext();
 
 export const useCart = () => useContext(CartContext);
 
 export const CartProvider = ({ children }) => {
-  const [items, setItems] = useState([]);
+  // initialize cart from localStorage to persist items across sessions
+  const [items, setItems] = useState(() => {
+    try {
+      const stored = localStorage.getItem('cart_items');
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  // keep localStorage in sync with cart state
+  useEffect(() => {
+    localStorage.setItem('cart_items', JSON.stringify(items));
+  }, [items]);
 
   const addItem = (item) => {
-    // ensure each item stored in the cart has an id property
     const id = item.id ?? Date.now() + Math.random();
-    setItems((prev) => [...prev, { ...item, id }]);
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === id);
+      if (existing) {
+        return prev.map((i) =>
+          i.id === id ? { ...i, quantity: i.quantity + 1 } : i
+        );
+      }
+      return [...prev, { ...item, id, quantity: 1 }];
+    });
   };
 
   const removeItem = (id) => {
-    // remove item by matching its id instead of using the array index
     setItems((prev) => prev.filter((i) => i.id !== id));
   };
 
+  const increaseItem = (id) => {
+    setItems((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, quantity: i.quantity + 1 } : i))
+    );
+  };
+
+  const decreaseItem = (id) => {
+    setItems((prev) =>
+      prev.flatMap((i) => {
+        if (i.id === id) {
+          if (i.quantity > 1) {
+            return { ...i, quantity: i.quantity - 1 };
+          }
+          return [];
+        }
+        return i;
+      })
+    );
+  };
+
   return (
-    <CartContext.Provider value={{ items, addItem, removeItem }}>
+    <CartContext.Provider
+      value={{ items, addItem, removeItem, increaseItem, decreaseItem }}
+    >
       {children}
     </CartContext.Provider>
   );

--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { FaPlus, FaMinus } from 'react-icons/fa';
 import { useCart } from './CartContext';
 import Spinner from './Spinner';
 import { useLanguage } from './LanguageContext';
@@ -33,7 +34,7 @@ const CartWrapper = styled.div`
 
 const Item = styled.div`
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr auto auto auto;
   align-items: center;
   gap: 1rem;
   padding: 0.75rem 1rem;
@@ -69,6 +70,20 @@ const Item = styled.div`
   }
 `;
 
+const Quantity = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const Control = styled.button`
+  background-color: var(--gray);
+  color: var(--white);
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+`;
+
 const Total = styled.p`
   font-weight: bold;
   font-size: 1.25rem;
@@ -77,7 +92,7 @@ const Total = styled.p`
 `;
 
 const CartPage = () => {
-  const { items, removeItem } = useCart();
+  const { items, removeItem, increaseItem, decreaseItem } = useCart();
   const [loading, setLoading] = useState(true);
   const { t } = useLanguage();
 
@@ -86,7 +101,7 @@ const CartPage = () => {
     return () => clearTimeout(timer);
   }, []);
 
-  const total = items.reduce((sum, item) => sum + item.price, 0);
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
 
   if (loading) return <Spinner />;
 
@@ -99,7 +114,16 @@ const CartPage = () => {
           {items.map((item) => (
             <Item key={item.id}>
               <span>{item.name}</span>
-              <span>{item.price}€</span>
+              <Quantity>
+                <Control aria-label={t('cart.decrease')} onClick={() => decreaseItem(item.id)}>
+                  <FaMinus size={12} />
+                </Control>
+                <span>{item.quantity}</span>
+                <Control aria-label={t('cart.increase')} onClick={() => increaseItem(item.id)}>
+                  <FaPlus size={12} />
+                </Control>
+              </Quantity>
+              <span>{item.price * item.quantity}€</span>
               <button onClick={() => removeItem(item.id)}>{t('cart.remove')}</button>
             </Item>
           ))}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -57,7 +57,10 @@
     "title": "Cart",
     "empty": "No items in cart.",
     "remove": "Remove",
-    "total": "Total"
+    "total": "Total",
+    "quantity": "Qty",
+    "increase": "Increase",
+    "decrease": "Decrease"
   },
   "booking": {
     "title": "Book your ticket",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -57,7 +57,10 @@
     "title": "Carrello",
     "empty": "Nessun elemento nel carrello.",
     "remove": "Rimuovi",
-    "total": "Total"
+    "total": "Total",
+    "quantity": "Qtà",
+    "increase": "Aumenta",
+    "decrease": "Diminuisci"
   },
   "booking": {
     "title": "Prenota il tuo biglietto",


### PR DESCRIPTION
## Summary
- persist cart items to localStorage
- support item quantities with increase/decrease controls
- show quantity and subtotal in the cart page
- update Italian and English translations

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845d230f6d883248d776a705ebfa6d2