### PR TITLE
Improve usability and integrate backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ npm run dev
 
 The server binds to `0.0.0.0` on port `5173` (or the next available port) so it can be accessed from outside the container using `localhost`.
 
+## Backend server
+
+Run the API server with:
+
+```bash
+npm run server
+```
+
 Visita `/prenota` per il form di prenotazione dei biglietti collegato a Firebase.
 
 ## Configurazione Firebase
@@ -22,7 +30,8 @@ Visita `/prenota` per il form di prenotazione dei biglietti collegato a Firebase
 npm install firebase
 ```
 
-Il file `src/firebase/functions.js` contiene la funzione `saveBooking` che salva i dati nella collezione `bookings` di Firestore.
+Il file `server/index.js` espone l'endpoint `POST /api/bookings` che salva i dati nella collezione `bookings` di Firestore tramite Firebase Admin. Imposta la variabile `GOOGLE_APPLICATION_CREDENTIALS` con il percorso del tuo service account.
+È inoltre disponibile l'endpoint `GET /api/events` che restituisce l'elenco degli eventi.
 
 ## Deploy dell'applicazione
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "firebase": "^11.9.0",

--- a/server/firebase.js
+++ b/server/firebase.js
@@ -1,0 +1,8 @@
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+initializeApp({
+  credential: applicationDefault(),
+});
+
+export const db = getFirestore();

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,66 @@
+import express from 'express';
+import cors from 'cors';
+import { db } from './firebase.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const events = [
+  {
+    id: 1,
+    date: '2024-07-01',
+    place: 'Roma',
+    time: '21:00',
+    price: 25,
+    image: 'https://source.unsplash.com/400x300/?concert',
+    description: "Serata di apertura dell'estate con DJ Alpha.",
+  },
+  {
+    id: 2,
+    date: '2024-08-15',
+    place: 'Milano',
+    time: '22:00',
+    price: 30,
+    image: 'https://source.unsplash.com/400x300/?party',
+    description: 'Ferragosto in musica con i migliori DJ italiani.',
+  },
+  {
+    id: 3,
+    date: '2024-09-10',
+    place: 'Napoli',
+    time: '20:00',
+    price: 20,
+    image: 'https://source.unsplash.com/400x300/?dj',
+    description: 'Chiusura della stagione estiva sul lungomare.',
+  },
+];
+
+app.get('/api/events', (req, res) => {
+  res.json(events);
+});
+
+app.post('/api/bookings', async (req, res) => {
+  const { nome, cognome, email, telefono } = req.body;
+  if (!nome || !cognome || !email || !telefono) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    await db.collection('bookings').add({
+      nome,
+      cognome,
+      email,
+      telefono,
+      createdAt: new Date(),
+    });
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save booking' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "djscovery-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "firebase-admin": "^11.10.1"
+  }
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,15 @@
+export const fetchEvents = async () => {
+  const res = await fetch('/api/events');
+  if (!res.ok) throw new Error('Failed to load events');
+  return res.json();
+};
+
+export const sendBooking = async (data) => {
+  const res = await fetch('/api/bookings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to save booking');
+  return res.json();
+};

--- a/src/components/EventiSection.jsx
+++ b/src/components/EventiSection.jsx
@@ -1,40 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { useCart } from './CartContext';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from './LanguageContext';
 import { FaCalendarAlt, FaClock, FaMapMarkerAlt, FaEuroSign } from 'react-icons/fa';
+import { fetchEvents } from '../api';
+import Spinner from './Spinner';
 
-const eventi = [
-  {
-    id: 1,
-    date: '2024-07-01',
-    place: 'Roma',
-    time: '21:00',
-    price: 25,
-    image: 'https://source.unsplash.com/400x300/?concert',
-    description: "Serata di apertura dell'estate con DJ Alpha.",
-  },
-  {
-    id: 2,
-    date: '2024-08-15',
-    place: 'Milano',
-    time: '22:00',
-    price: 30,
-    image: 'https://source.unsplash.com/400x300/?party',
-    description: 'Ferragosto in musica con i migliori DJ italiani.',
-  },
-  {
-    id: 3,
-    date: '2024-09-10',
-    place: 'Napoli',
-    time: '20:00',
-    price: 20,
-    image: 'https://source.unsplash.com/400x300/?dj',
-    description: 'Chiusura della stagione estiva sul lungomare.',
-  },
-];
 
 const Section = styled.section`
   text-align: center;
@@ -101,14 +74,26 @@ const EventiSection = () => {
   const { addItem } = useCart();
   const navigate = useNavigate();
   const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [events, setEvents] = useState([]);
   const { t } = useLanguage();
+
+  useEffect(() => {
+    fetchEvents()
+      .then(setEvents)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
   return (
   <Section>
     <div className="container">
       <h2>{t('events.title')}</h2>
       <p>{t('events.subtitle')}</p>
+      {loading && <Spinner aria-label={t('events.loading')} />}
+      {!loading && events.length === 0 && <p>{t('events.none')}</p>}
       <Cards>
-        {eventi.map(event => (
+        {events.map(event => (
           <Card
             key={event.id}
             initial={{ opacity: 0, y: 30 }}

--- a/src/components/Spinner.jsx
+++ b/src/components/Spinner.jsx
@@ -16,6 +16,6 @@ const Disc = styled.div`
   margin: 2rem auto;
 `;
 
-const Spinner = () => <Disc />;
+const Spinner = (props) => <Disc role="status" {...props} />;
 
 export default Spinner;

--- a/src/components/TicketBookingForm.jsx
+++ b/src/components/TicketBookingForm.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { saveBooking } from '../firebase/functions';
+import { sendBooking } from '../api';
 import { useLanguage } from './LanguageContext';
+import Spinner from './Spinner';
 
 const Wrapper = styled.section`
   text-align: center;
@@ -56,6 +57,7 @@ const TicketBookingForm = () => {
   });
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const { t } = useLanguage();
 
   const handleChange = (e) => {
@@ -76,13 +78,16 @@ const TicketBookingForm = () => {
       return;
     }
     setError('');
+    setLoading(true);
     try {
-      await saveBooking(formData);
+      await sendBooking(formData);
       setSuccess(true);
       setFormData({ nome: '', cognome: '', email: '', telefono: '' });
       setTimeout(() => setSuccess(false), 2000);
     } catch (err) {
       setError(t('booking.error'));
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -120,7 +125,10 @@ const TicketBookingForm = () => {
             onChange={handleChange}
             required
           />
-          <Button type="submit">{t('booking.book')}</Button>
+          <Button type="submit" disabled={loading}>
+            {t('booking.book')}
+          </Button>
+          {loading && <Spinner />}
         </Form>
         {error && <p>{error}</p>}
         {success && <p>{t('booking.success')}</p>}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,6 +26,8 @@
   "events": {
     "title": "Next Events",
     "subtitle": "Discover and book our special nights throughout Italy.",
+    "loading": "Loading events...",
+    "none": "No events available",
     "book_now": "Book now",
     "added": "Added to cart!"
   },

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -26,6 +26,8 @@
   "events": {
     "title": "Prossimi Eventi",
     "subtitle": "Scopri e prenota le nostre serate speciali in tutta Italia.",
+    "loading": "Caricamento eventi...",
+    "none": "Nessun evento disponibile",
     "book_now": "Prenota ora",
     "added": "Aggiunto al carrello!"
   },


### PR DESCRIPTION
## Summary
- add Express backend server with API endpoints
- create helper API functions
- show loading spinners when booking tickets or fetching events
- fetch events from backend
- document backend usage
- add server start script in package.json

## Testing
- `npm install`
- `npm run build`
- `npm start` in `server/`

------
https://chatgpt.com/codex/tasks/task_e_68502ab57ca08324833636ba94a1a954