### PR TITLE
Remove shop and cart, add home slider

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,7 @@ import styled from 'styled-components';
 import Navbar from './components/Navbar';
 import HomePage from './components/HomePage';
 import EventiSection from './components/EventiSection';
-import ShopSection from './components/ShopSection';
 import GallerySection from './components/GallerySection';
-import CartPage from './components/CartPage';
 import ChiSiamoSection from './components/ChiSiamoSection';
 import ContattiSection from './components/ContattiSection';
 import Footer from './components/Footer';
@@ -29,9 +27,7 @@ const App = () => {
           <Routes location={location} key={location.pathname}>
             <Route path="/" element={<HomePage />} />
             <Route path="/eventi" element={<EventiSection />} />
-            <Route path="/shop" element={<ShopSection />} />
             <Route path="/gallery" element={<GallerySection />} />
-            <Route path="/carrello" element={<CartPage />} />
             <Route path="/chi-siamo" element={<ChiSiamoSection />} />
             <Route path="/contatti" element={<ContattiSection />} />
             <Route path="/prenota" element={<TicketBookingForm />} />

--- a/src/components/EventiSection.jsx
+++ b/src/components/EventiSection.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
-import { useCart } from './CartContext';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from './LanguageContext';
 import { FaCalendarAlt, FaClock, FaMapMarkerAlt, FaEuroSign } from 'react-icons/fa';
@@ -71,9 +70,7 @@ const Button = styled(motion.button)`
 `;
 
 const EventiSection = () => {
-  const { addItem } = useCart();
   const navigate = useNavigate();
-  const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(true);
   const [events, setEvents] = useState([]);
   const { t } = useLanguage();
@@ -113,15 +110,7 @@ const EventiSection = () => {
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
               onClick={() => {
-                addItem({
-                  id: event.id,
-                  name: `Biglietto ${event.place}`,
-                  price: event.price,
-                  image: event.image,
-                });
                 navigate('/prenota');
-                setMessage(t('events.added'));
-                setTimeout(() => setMessage(''), 2000);
               }}
             >
               {t('events.book_now')}
@@ -129,7 +118,6 @@ const EventiSection = () => {
           </Card>
         ))}
       </Cards>
-      {message && <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} style={{ color: 'var(--green)', marginTop: '1rem' }}>{message}</motion.p>}
     </div>
   </Section>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -67,7 +67,6 @@ const Footer = () => {
       <Menu>
         <Link to="/">{t('nav.home')}</Link>
         <Link to="/eventi">{t('nav.events')}</Link>
-        <Link to="/shop">{t('nav.shop')}</Link>
         <Link to="/chi-siamo">{t('nav.about')}</Link>
         <Link to="/contatti">{t('nav.contacts')}</Link>
       </Menu>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -67,14 +67,6 @@ const BtnPrimary = styled(motion(Link))`
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
 `;
 
-const BtnSecondary = styled(motion(Link))`
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
-  background-color: var(--yellow);
-  color: var(--black);
-  font-weight: bold;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
-`;
 
 const HeroSection = () => {
   const { t } = useLanguage();
@@ -115,13 +107,6 @@ const HeroSection = () => {
           >
             {t('hero.cta_events')}
           </BtnPrimary>
-          <BtnSecondary
-            to="/shop"
-            whileHover={{ scale: 1.05, boxShadow: '0 0 12px var(--yellow)' }}
-            whileTap={{ scale: 0.95 }}
-          >
-            {t('hero.cta_shop')}
-          </BtnSecondary>
         </CTAWrapper>
       </Content>
     </Section>

--- a/src/components/HomeGallerySlider.jsx
+++ b/src/components/HomeGallerySlider.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination, Autoplay } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import img1 from '../assets/img/Copia di Testo del paragraf.png';
+import img2 from '../assets/img/Copia di Testo del paragrafo.png';
+import img3 from '../assets/img/DJSCOVERY LOGO.png';
+import img4 from '../assets/img/LOGO PRINCIPALE.png';
+import img5 from '../assets/img/Testo del paragrafo_HQ.png';
+import img6 from '../assets/img/Testo del paragrafo_HQ2.png';
+import img7 from '../assets/img/hero.png';
+import img8 from '../assets/img/logo-dj.png';
+
+const Section = styled.section`
+  background-color: #222;
+  padding: 2rem 0;
+  text-align: center;
+`;
+
+const SlideImage = styled.img`
+  width: 100%;
+  height: 400px;
+  object-fit: cover;
+  border-radius: 8px;
+`;
+
+const images = [img1, img2, img3, img4, img5, img6, img7, img8];
+
+const HomeGallerySlider = () => (
+  <Section>
+    <div className="container">
+      <Swiper
+        modules={[Navigation, Pagination, Autoplay]}
+        navigation
+        pagination={{ clickable: true }}
+        autoplay={{ delay: 3000 }}
+        loop
+        style={{ borderRadius: '8px' }}
+      >
+        {images.map((src, idx) => (
+          <SwiperSlide key={idx}>
+            <SlideImage src={src} alt="gallery item" loading="lazy" />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  </Section>
+);
+
+export default HomeGallerySlider;

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import HeroSection from './HeroSection';
-import GallerySection from './GallerySection';
+import HomeGallerySlider from './HomeGallerySlider';
 import NewsletterSection from './NewsletterSection';
 
 const HomePage = () => (
   <>
     <HeroSection />
-    <GallerySection />
+    <HomeGallerySlider />
     <NewsletterSection />
   </>
 );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,9 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link, NavLink } from "react-router-dom";
 import styled from "styled-components";
 import { motion } from "framer-motion";
-import { FaShoppingBag } from "react-icons/fa";
 import { FiMenu, FiX } from "react-icons/fi";
-import { useCart } from "./CartContext";
 import { useLanguage } from "./LanguageContext";
 import LanguageSelector from "./LanguageSelector";
 import logoImg from "../assets/img/logo-dj.png";
@@ -115,40 +113,11 @@ const MenuItem = styled(motion.li)`
   }
 `;
 
-const CartLink = styled(motion(NavLink))`
-  position: relative;
-  display: flex;
-  align-items: center;
-  transition: transform 0.2s;
-
-  svg {
-    color: var(--white);
-  }
-`;
-
-const CartCount = styled.span`
-  position: absolute;
-  top: -4px;
-  right: -8px;
-  background-color: var(--green);
-  color: var(--white);
-  border-radius: 50%;
-  height: 1.25rem;
-  min-width: 1.25rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 4px;
-  font-size: 0.75rem;
-  line-height: 1;
-`;
 
 const Navbar = () => {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [isDesktop, setIsDesktop] = useState(window.innerWidth > 768);
-  const { items } = useCart();
-  const totalItems = items.reduce((sum, item) => sum + item.quantity, 0);
   const { t } = useLanguage();
 
   useEffect(() => {
@@ -219,11 +188,6 @@ const Navbar = () => {
               </NavLink>
             </MenuItem>
             <MenuItem whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
-              <NavLink to="/shop" onClick={() => setOpen(false)}>
-                {t('nav.shop')}
-              </NavLink>
-            </MenuItem>
-            <MenuItem whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
               <NavLink to="/chi-siamo" onClick={() => setOpen(false)}>
                 {t('nav.about')}
               </NavLink>
@@ -234,16 +198,6 @@ const Navbar = () => {
               </NavLink>
             </MenuItem>
           </Menu>
-          <CartLink
-            to="/carrello"
-            aria-label={t('nav.cart')}
-            onClick={() => setOpen(false)}
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            <FaShoppingBag size={20} />
-            {totalItems > 0 && <CartCount>{totalItems}</CartCount>}
-          </CartLink>
           <LanguageSelector />
         </RightSection>
       </Container>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,17 +2,14 @@
   "nav": {
     "home": "Home",
     "events": "Events",
-    "shop": "Shop",
     "gallery": "Gallery",
     "about": "About Us",
-    "contacts": "Contacts",
-    "cart": "Cart"
+    "contacts": "Contacts"
   },
   "hero": {
     "title": "Music & Travel",
     "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae vehicula magna.",
-    "cta_events": "Discover upcoming events",
-    "cta_shop": "Visit the shop"
+    "cta_events": "Discover upcoming events"
   },
   "gallery": {
     "title": "Gallery"
@@ -29,14 +26,7 @@
     "subtitle": "Discover and book our special nights throughout Italy.",
     "loading": "Loading events...",
     "none": "No events available",
-    "book_now": "Book now",
-    "added": "Added to cart!"
-  },
-  "shop": {
-    "title": "Shop",
-    "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    "add_to_cart": "Add to cart",
-    "added": "Added to cart!"
+    "book_now": "Book now"
   },
   "about": {
     "title": "About Us",
@@ -55,15 +45,6 @@
   "footer": {
     "text": "Lorem ipsum dolor sit amet.",
     "copy": "DJSCOVERY"
-  },
-  "cart": {
-    "title": "Cart",
-    "empty": "No items in cart.",
-    "remove": "Remove",
-    "total": "Total",
-    "quantity": "Qty",
-    "increase": "Increase",
-    "decrease": "Decrease"
   },
   "booking": {
     "title": "Book your ticket",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2,17 +2,14 @@
   "nav": {
     "home": "Home",
     "events": "Eventi",
-    "shop": "Shop",
     "gallery": "Galleria",
     "about": "Chi Siamo",
-    "contacts": "Contatti",
-    "cart": "Carrello"
+    "contacts": "Contatti"
   },
   "hero": {
     "title": "Music & Travel",
     "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae vehicula magna.",
-    "cta_events": "Scopri i prossimi eventi",
-    "cta_shop": "Visita lo shop"
+    "cta_events": "Scopri i prossimi eventi"
   },
   "gallery": {
     "title": "Gallery"
@@ -29,14 +26,7 @@
     "subtitle": "Scopri e prenota le nostre serate speciali in tutta Italia.",
     "loading": "Caricamento eventi...",
     "none": "Nessun evento disponibile",
-    "book_now": "Prenota ora",
-    "added": "Aggiunto al carrello!"
-  },
-  "shop": {
-    "title": "Shop",
-    "subtitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-    "add_to_cart": "Aggiungi al carrello",
-    "added": "Aggiunto al carrello!"
+    "book_now": "Prenota ora"
   },
   "about": {
     "title": "Chi Siamo",
@@ -55,15 +45,6 @@
   "footer": {
     "text": "Lorem ipsum dolor sit amet.",
     "copy": "DJSCOVERY"
-  },
-  "cart": {
-    "title": "Carrello",
-    "empty": "Nessun elemento nel carrello.",
-    "remove": "Rimuovi",
-    "total": "Totale",
-    "quantity": "Qtà",
-    "increase": "Aumenta",
-    "decrease": "Diminuisci"
   },
   "booking": {
     "title": "Prenota il tuo biglietto",


### PR DESCRIPTION
## Summary
- drop Shop and Cart routes and navigation
- remove shop CTA from hero and translations
- refactor events booking button
- create `HomeGallerySlider` and use on home page
- trim unused localization entries

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853b95a0d8c8324a356f277a148e16c