### PR TITLE
Add admin panel for events and bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ npm run server
 
 Visita `/prenota` per il form di prenotazione dei biglietti collegato a Firebase.
 
+## Area admin
+
+Imposta la variabile `VITE_ADMIN_PASSWORD` con la password desiderata e visita
+`/admin` per accedere al pannello di amministrazione. Da qui potrai vedere le
+prenotazioni salvate e creare nuovi eventi che compariranno nella sezione eventi
+pubblica.
+
 ## Configurazione Firebase
 
 1. Crea un progetto su [Firebase Console](https://console.firebase.google.com/) e abilita **Firestore**.

--- a/server/index.js
+++ b/server/index.js
@@ -6,38 +6,38 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-const events = [
-  {
-    id: 1,
-    date: '2024-07-01',
-    place: 'Roma',
-    time: '21:00',
-    price: 25,
-    image: 'https://source.unsplash.com/400x300/?concert',
-    description: "Serata di apertura dell'estate con DJ Alpha.",
-  },
-  {
-    id: 2,
-    date: '2024-08-15',
-    place: 'Milano',
-    time: '22:00',
-    price: 30,
-    image: 'https://source.unsplash.com/400x300/?party',
-    description: 'Ferragosto in musica con i migliori DJ italiani.',
-  },
-  {
-    id: 3,
-    date: '2024-09-10',
-    place: 'Napoli',
-    time: '20:00',
-    price: 20,
-    image: 'https://source.unsplash.com/400x300/?dj',
-    description: 'Chiusura della stagione estiva sul lungomare.',
-  },
-];
+// Get events from Firestore
+app.get('/api/events', async (req, res) => {
+  try {
+    const snapshot = await db.collection('events').get();
+    const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load events' });
+  }
+});
 
-app.get('/api/events', (req, res) => {
-  res.json(events);
+// Create a new event
+app.post('/api/events', async (req, res) => {
+  const { date, place, time, price, image, description } = req.body;
+  if (!date || !place || !time || !price || !image || !description) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const doc = await db.collection('events').add({
+      date,
+      place,
+      time,
+      price,
+      image,
+      description,
+    });
+    res.json({ id: doc.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create event' });
+  }
 });
 
 app.post('/api/bookings', async (req, res) => {
@@ -57,6 +57,18 @@ app.post('/api/bookings', async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to save booking' });
+  }
+});
+
+// Retrieve all bookings
+app.get('/api/bookings', async (req, res) => {
+  try {
+    const snapshot = await db.collection('bookings').orderBy('createdAt', 'desc').get();
+    const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load bookings' });
   }
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,8 @@ import ChiSiamoSection from './components/ChiSiamoSection';
 import ContattiSection from './components/ContattiSection';
 import Footer from './components/Footer';
 import TicketBookingForm from './components/TicketBookingForm';
+import AdminLogin from './components/AdminLogin';
+import AdminPanel from './components/AdminPanel';
 
 const Main = styled.main`
   flex: 1;
@@ -35,6 +37,8 @@ const App = () => {
             <Route path="/chi-siamo" element={<ChiSiamoSection />} />
             <Route path="/contatti" element={<ContattiSection />} />
             <Route path="/prenota" element={<TicketBookingForm />} />
+            <Route path="/admin" element={<AdminLogin />} />
+            <Route path="/admin/panel" element={<AdminPanel />} />
           </Routes>
         </AnimatePresence>
       </Main>

--- a/src/api.js
+++ b/src/api.js
@@ -13,3 +13,19 @@ export const sendBooking = async (data) => {
   if (!res.ok) throw new Error('Failed to save booking');
   return res.json();
 };
+
+export const fetchBookings = async () => {
+  const res = await fetch('/api/bookings');
+  if (!res.ok) throw new Error('Failed to load bookings');
+  return res.json();
+};
+
+export const createEvent = async (data) => {
+  const res = await fetch('/api/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create event');
+  return res.json();
+};

--- a/src/components/AdminLogin.jsx
+++ b/src/components/AdminLogin.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const Wrapper = styled.section`
+  text-align: center;
+  min-height: calc(100vh - 200px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: rgba(0,0,0,0.3);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+`;
+
+const Input = styled.input`
+  padding: 0.75rem;
+  border: 1px solid var(--gray);
+  border-radius: 4px;
+  background-color: #111;
+  color: var(--white);
+`;
+
+const Button = styled.button`
+  padding: 0.75rem;
+  background-color: var(--red);
+  color: var(--white);
+`;
+
+const AdminLogin = () => {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const expected = import.meta.env.VITE_ADMIN_PASSWORD || 'admin';
+    if (password === expected) {
+      localStorage.setItem('isAdmin', 'true');
+      navigate('/admin/panel');
+    } else {
+      setError('Password errata');
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Form onSubmit={handleSubmit}>
+        <h2>Admin Login</h2>
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button type="submit">Login</Button>
+        {error && <p>{error}</p>}
+      </Form>
+    </Wrapper>
+  );
+};
+
+export default AdminLogin;

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { fetchBookings, createEvent } from '../api';
+
+const Wrapper = styled.section`
+  text-align: center;
+  padding: 2rem 0;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 2rem;
+  th, td {
+    padding: 0.5rem;
+    border: 1px solid var(--gray);
+  }
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  margin: 0 auto;
+`;
+
+const Input = styled.input`
+  padding: 0.75rem;
+  border: 1px solid var(--gray);
+  border-radius: 4px;
+  background-color: #111;
+  color: var(--white);
+`;
+
+const Button = styled.button`
+  padding: 0.75rem;
+  background-color: var(--red);
+  color: var(--white);
+`;
+
+const AdminPanel = () => {
+  const [bookings, setBookings] = useState([]);
+  const [formData, setFormData] = useState({
+    date: '',
+    place: '',
+    time: '',
+    price: '',
+    image: '',
+    description: '',
+  });
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (localStorage.getItem('isAdmin') !== 'true') {
+      navigate('/admin');
+      return;
+    }
+    fetchBookings().then(setBookings).catch(() => {});
+  }, [navigate]);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createEvent(formData);
+      setMessage('Evento creato');
+      setFormData({ date: '', place: '', time: '', price: '', image: '', description: '' });
+    } catch (err) {
+      setMessage('Errore');
+    }
+  };
+
+  return (
+    <Wrapper>
+      <div className="container">
+        <h2>Admin Panel</h2>
+        <h3>Prenotazioni</h3>
+        <Table>
+          <thead>
+            <tr>
+              <th>Nome</th>
+              <th>Cognome</th>
+              <th>Email</th>
+              <th>Telefono</th>
+              <th>Biglietti</th>
+            </tr>
+          </thead>
+          <tbody>
+            {bookings.map((b) => (
+              <tr key={b.id}>
+                <td>{b.nome}</td>
+                <td>{b.cognome}</td>
+                <td>{b.email}</td>
+                <td>{b.telefono}</td>
+                <td>{b.quantity || 1}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+
+        <h3>Crea Evento</h3>
+        <Form onSubmit={handleSubmit}>
+          <Input name="date" placeholder="Data" value={formData.date} onChange={handleChange} />
+          <Input name="place" placeholder="Luogo" value={formData.place} onChange={handleChange} />
+          <Input name="time" placeholder="Orario" value={formData.time} onChange={handleChange} />
+          <Input name="price" placeholder="Prezzo" value={formData.price} onChange={handleChange} />
+          <Input name="image" placeholder="URL immagine" value={formData.image} onChange={handleChange} />
+          <Input name="description" placeholder="Descrizione" value={formData.description} onChange={handleChange} />
+          <Button type="submit">Crea</Button>
+        </Form>
+        {message && <p>{message}</p>}
+      </div>
+    </Wrapper>
+  );
+};
+
+export default AdminPanel;


### PR DESCRIPTION
## Summary
- use Firestore for `/api/events` and add creation endpoint
- expose `/api/bookings` to list bookings
- add admin login page and admin panel with booking table and event creation
- expose admin routes in `App.jsx`
- document admin password env variable in README

## Testing
- `npm install`
- `npm run build`
- `cd server && npm install`
- `npm start` (then stopped)

------
https://chatgpt.com/codex/tasks/task_e_6853bac5e7788324a2afaa24f67ade60