### PR TITLE
Improve admin panel separation and functionality

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -40,6 +40,17 @@ app.post('/api/events', async (req, res) => {
   }
 });
 
+// Delete an event
+app.delete('/api/events/:id', async (req, res) => {
+  try {
+    await db.collection('events').doc(req.params.id).delete();
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete event' });
+  }
+});
+
 app.post('/api/bookings', async (req, res) => {
   const { nome, cognome, email, telefono } = req.body;
   if (!nome || !cognome || !email || !telefono) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,9 +21,10 @@ const Main = styled.main`
 
 const App = () => {
   const location = useLocation();
+  const isAdminRoute = location.pathname.startsWith('/admin');
   return (
     <>
-      <Navbar />
+      {!isAdminRoute && <Navbar />}
       <Main>
         <AnimatePresence mode="wait">
           <Routes location={location} key={location.pathname}>
@@ -38,7 +39,7 @@ const App = () => {
           </Routes>
         </AnimatePresence>
       </Main>
-      <Footer />
+      {!isAdminRoute && <Footer />}
     </>
   );
 };

--- a/src/api.js
+++ b/src/api.js
@@ -29,3 +29,9 @@ export const createEvent = async (data) => {
   if (!res.ok) throw new Error('Failed to create event');
   return res.json();
 };
+
+export const deleteEvent = async (id) => {
+  const res = await fetch(`/api/events/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete event');
+  return res.json();
+};


### PR DESCRIPTION
## Summary
- conditionally hide Navbar and Footer on admin pages
- allow admins to delete events from the new Events section
- expose `DELETE /api/events/:id` endpoint
- style admin panel with Djscovery colors and add logout button

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853c3a4754c8324bbeeda1371b59493