### PR TITLE
Improve admin panel and add mock API

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,10 +1,22 @@
+import {
+  mockFetchEvents,
+  mockSendBooking,
+  mockFetchBookings,
+  mockCreateEvent,
+  mockDeleteEvent,
+} from './mockApi';
+
+const useMock = import.meta.env.VITE_MOCK !== 'false';
+
 export const fetchEvents = async () => {
+  if (useMock) return mockFetchEvents();
   const res = await fetch('/api/events');
   if (!res.ok) throw new Error('Failed to load events');
   return res.json();
 };
 
 export const sendBooking = async (data) => {
+  if (useMock) return mockSendBooking(data);
   const res = await fetch('/api/bookings', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -15,12 +27,14 @@ export const sendBooking = async (data) => {
 };
 
 export const fetchBookings = async () => {
+  if (useMock) return mockFetchBookings();
   const res = await fetch('/api/bookings');
   if (!res.ok) throw new Error('Failed to load bookings');
   return res.json();
 };
 
 export const createEvent = async (data) => {
+  if (useMock) return mockCreateEvent(data);
   const res = await fetch('/api/events', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -31,6 +45,7 @@ export const createEvent = async (data) => {
 };
 
 export const deleteEvent = async (id) => {
+  if (useMock) return mockDeleteEvent(id);
   const res = await fetch(`/api/events/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete event');
   return res.json();

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -20,11 +20,16 @@ import {
   TableCell,
   TableBody,
   Divider,
+  IconButton,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import EventIcon from '@mui/icons-material/Event';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CalendarIcon from '@mui/icons-material/CalendarToday';
+import MenuIcon from '@mui/icons-material/Menu';
+import LogoutIcon from '@mui/icons-material/Logout';
 
 const drawerWidth = 240;
 
@@ -41,6 +46,9 @@ const AdminPanel = () => {
   });
   const [message, setMessage] = useState('');
   const [section, setSection] = useState('bookings');
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [mobileOpen, setMobileOpen] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -89,19 +97,19 @@ const AdminPanel = () => {
       <Toolbar />
       <Divider />
       <List>
-        <ListItem button onClick={() => setSection('bookings')} selected={section === 'bookings'}>
+        <ListItem button onClick={() => {setSection('bookings'); setMobileOpen(false);}} selected={section === 'bookings'}>
           <ListItemIcon>
             <ListAltIcon />
           </ListItemIcon>
           <ListItemText primary="Prenotazioni" />
         </ListItem>
-        <ListItem button onClick={() => setSection('events')} selected={section === 'events'}>
+        <ListItem button onClick={() => {setSection('events'); setMobileOpen(false);}} selected={section === 'events'}>
           <ListItemIcon>
             <CalendarIcon />
           </ListItemIcon>
           <ListItemText primary="Eventi" />
         </ListItem>
-        <ListItem button onClick={() => setSection('create')} selected={section === 'create'}>
+        <ListItem button onClick={() => {setSection('create'); setMobileOpen(false);}} selected={section === 'create'}>
           <ListItemIcon>
             <EventIcon />
           </ListItemIcon>
@@ -117,16 +125,26 @@ const AdminPanel = () => {
       <AppBar position="fixed"
         sx={{ zIndex: (theme) => theme.zIndex.drawer + 1, backgroundColor: 'var(--black)', color: 'var(--yellow)' }}>
         <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <Typography variant="h6" noWrap component="div">
-            Admin Panel
-          </Typography>
-          <Button color="inherit" onClick={() => { localStorage.removeItem('isAdmin'); navigate('/'); }}>
-            Logout
-          </Button>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {isMobile && (
+              <IconButton color="inherit" onClick={() => setMobileOpen(true)}>
+                <MenuIcon />
+              </IconButton>
+            )}
+            <Typography variant="h6" noWrap component="div">
+              Admin Panel
+            </Typography>
+          </Box>
+          <IconButton color="inherit" onClick={() => { localStorage.removeItem('isAdmin'); navigate('/'); }}>
+            <LogoutIcon />
+          </IconButton>
         </Toolbar>
       </AppBar>
       <Drawer
-        variant="permanent"
+        variant={isMobile ? 'temporary' : 'permanent'}
+        open={isMobile ? mobileOpen : true}
+        onClose={() => setMobileOpen(false)}
+        ModalProps={{ keepMounted: true }}
         sx={{
           width: drawerWidth,
           flexShrink: 0,
@@ -147,6 +165,7 @@ const AdminPanel = () => {
             <Typography variant="h5" gutterBottom>
               Prenotazioni
             </Typography>
+            <Box sx={{ overflowX: 'auto' }}>
             <Table>
               <TableHead>
                 <TableRow>
@@ -169,6 +188,7 @@ const AdminPanel = () => {
                 ))}
               </TableBody>
             </Table>
+            </Box>
           </Box>
         )}
         {section === 'events' && (
@@ -176,6 +196,7 @@ const AdminPanel = () => {
             <Typography variant="h5" gutterBottom>
               Eventi
             </Typography>
+            <Box sx={{ overflowX: 'auto' }}>
             <Table>
               <TableHead>
                 <TableRow>
@@ -200,6 +221,7 @@ const AdminPanel = () => {
                 ))}
               </TableBody>
             </Table>
+            </Box>
           </Box>
         )}
         {section === 'create' && (
@@ -213,8 +235,8 @@ const AdminPanel = () => {
             <TextField name="price" label="Prezzo" variant="outlined" value={formData.price} onChange={handleChange} fullWidth />
             <TextField name="image" label="URL immagine" variant="outlined" value={formData.image} onChange={handleChange} fullWidth />
             <TextField name="description" label="Descrizione" variant="outlined" value={formData.description} onChange={handleChange} fullWidth />
-            <Button type="submit" variant="contained"
-              sx={{ backgroundColor: 'var(--red)', '&:hover': { backgroundColor: '#c62828' } }}>
+            <Button type="submit" variant="contained" fullWidth={isMobile}
+              sx={{ alignSelf: isMobile ? 'stretch' : 'flex-start', backgroundColor: 'var(--red)', '&:hover': { backgroundColor: '#c62828' } }}>
               Crea
             </Button>
             {message && <Typography>{message}</Typography>}

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -1,0 +1,67 @@
+export let mockEvents = [
+  {
+    id: '1',
+    place: 'Milano',
+    date: '2024-05-10',
+    time: '22:00',
+    price: '20',
+    image: '',
+    description: 'Serata di prova'
+  }
+];
+
+export let mockBookings = [
+  {
+    id: '1',
+    nome: 'Mario',
+    cognome: 'Rossi',
+    email: 'mario@example.com',
+    telefono: '3331234567',
+    quantity: 1
+  }
+];
+
+const save = () => {
+  localStorage.setItem('mockEvents', JSON.stringify(mockEvents));
+  localStorage.setItem('mockBookings', JSON.stringify(mockBookings));
+};
+
+export const loadMock = () => {
+  const e = localStorage.getItem('mockEvents');
+  if (e) mockEvents = JSON.parse(e);
+  const b = localStorage.getItem('mockBookings');
+  if (b) mockBookings = JSON.parse(b);
+};
+
+export const mockFetchEvents = async () => {
+  loadMock();
+  return mockEvents;
+};
+
+export const mockFetchBookings = async () => {
+  loadMock();
+  return mockBookings;
+};
+
+export const mockCreateEvent = async (data) => {
+  loadMock();
+  const newEvent = { id: Date.now().toString(), ...data };
+  mockEvents.push(newEvent);
+  save();
+  return newEvent;
+};
+
+export const mockDeleteEvent = async (id) => {
+  loadMock();
+  mockEvents = mockEvents.filter((e) => e.id !== id);
+  save();
+  return { success: true };
+};
+
+export const mockSendBooking = async (data) => {
+  loadMock();
+  const newBooking = { id: Date.now().toString(), ...data };
+  mockBookings.push(newBooking);
+  save();
+  return newBooking;
+};


### PR DESCRIPTION
## Summary
- add a mock API with localStorage persistence
- toggle between real and mock API in `src/api.js`
- redesign admin panel for mobile and desktop
- replace logout text with exit icon
- adjust create button for mobile

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853c5f559d08324b865db563a619a9a