### PR TITLE
Add responsive events grid

### DIFF
--- a/src/components/EventiSection.jsx
+++ b/src/components/EventiSection.jsx
@@ -18,7 +18,8 @@ import {
 
 const Section = styled.section`
   text-align: center;
-  background: linear-gradient(180deg, #111, #000);
+  background-color: #f7f7f7;
+  color: var(--black);
 `;
 
 const Cards = styled.div`
@@ -29,11 +30,11 @@ const Cards = styled.div`
   padding-bottom: 2rem;
 
   @media (min-width: 600px) {
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
   }
 
   @media (min-width: 992px) {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
   }
 `;
 
@@ -69,14 +70,17 @@ const EventiSection = () => {
             viewport={{ once: true }}
             whileHover={{ scale: 1.03 }}
             sx={{
-              backgroundColor: '#111',
-              border: '1px solid var(--gray)',
-              color: 'var(--white)',
+              backgroundColor: '#fff',
+              border: '1px solid #ddd',
+              color: 'var(--black)',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
               textAlign: 'left',
               width: '100%',
               margin: 0,
               display: 'flex',
               flexDirection: 'column',
+              borderRadius: '8px',
+              overflow: 'hidden',
             }}
           >
             <CardMedia
@@ -84,6 +88,7 @@ const EventiSection = () => {
               height="200"
               image={event.image || heroImg}
               alt={event.place}
+              sx={{ borderTopLeftRadius: '8px', borderTopRightRadius: '8px' }}
             />
             <CardContent sx={{ flex: '1 1 auto', padding: '1rem' }}>
               <Typography

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -1,14 +1,102 @@
 export let mockEvents = [
   {
     id: '1',
-    name: 'Evento di prova',
-    dj: 'DJ Test',
+    name: 'Wan Seend',
+    dj: 'DJ Alpha',
+    place: 'Roma',
+    date: '2027-05-10',
+    time: '21:00',
+    price: '15',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '2',
+    name: 'Night Beats',
+    dj: 'DJ Beta',
     place: 'Milano',
-    date: '2024-05-10',
-    time: '22:00',
+    date: '2027-06-15',
+    time: '22:30',
+    price: '18',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '3',
+    name: 'Electro Wave',
+    dj: 'DJ Gamma',
+    place: 'Torino',
+    date: '2027-07-20',
+    time: '20:00',
     price: '20',
     image: '',
-    description: 'Serata di prova'
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '4',
+    name: 'Bass Trip',
+    dj: 'DJ Delta',
+    place: 'Bologna',
+    date: '2027-08-05',
+    time: '23:00',
+    price: '22',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '5',
+    name: 'Sunset Vibes',
+    dj: 'DJ Epsilon',
+    place: 'Napoli',
+    date: '2027-09-12',
+    time: '19:00',
+    price: '17',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '6',
+    name: 'Moonlight Jam',
+    dj: 'DJ Zeta',
+    place: 'Firenze',
+    date: '2027-10-03',
+    time: '21:30',
+    price: '19',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '7',
+    name: 'Groove Town',
+    dj: 'DJ Eta',
+    place: 'Genova',
+    date: '2027-11-18',
+    time: '22:00',
+    price: '16',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '8',
+    name: 'Rave City',
+    dj: 'DJ Theta',
+    place: 'Verona',
+    date: '2027-12-09',
+    time: '20:30',
+    price: '21',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
+  },
+  {
+    id: '9',
+    name: 'Electro Fest',
+    dj: 'DJ Iota',
+    place: 'Bari',
+    date: '2028-01-14',
+    time: '22:00',
+    price: '24',
+    image: '',
+    description: 'Lorem ipsum dolor sit amet.'
   }
 ];
 


### PR DESCRIPTION
## Summary
- show events in a light 3-column grid with rounded cards
- include 9 placeholder events in the mock API

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855472dd884832490aa40d469a672b9