### PR TITLE
Disable arrows on gallery slider

### DIFF
--- a/src/components/HomeGallerySlider.jsx
+++ b/src/components/HomeGallerySlider.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Navigation, Pagination, Autoplay } from "swiper/modules";
+import { Pagination, Autoplay } from "swiper/modules";
 import "swiper/css";
-import "swiper/css/navigation";
 import "swiper/css/pagination";
 import img1 from "../assets/img/Copia di Testo del paragraf.png";
 import img2 from "../assets/img/Copia di Testo del paragrafo.png";
@@ -33,8 +32,7 @@ const HomeGallerySlider = () => (
   <Section>
     <div className="container">
       <Swiper
-        modules={[Navigation, Pagination, Autoplay]}
-        navigation
+        modules={[Pagination, Autoplay]}
         pagination={{ clickable: true }}
         autoplay={{ delay: 3000 }}
         loop


### PR DESCRIPTION
## Summary
- remove Swiper navigation import and prop so arrows don't show

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685566ada8988324a2ba45e0f879283e