### PR TITLE
Improve ID generation with uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-router-dom": "^6.21.1",
     "react-swipeable": "^7.0.2",
     "styled-components": "^6.1.1",
-    "swiper": "^11.2.8"
+    "swiper": "^11.2.8",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "vite": "^5.0.10"

--- a/src/components/CartContext.jsx
+++ b/src/components/CartContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { v4 as uuid } from 'uuid';
 
 const CartContext = createContext();
 
@@ -21,7 +22,7 @@ export const CartProvider = ({ children }) => {
   }, [items]);
 
   const addItem = (item) => {
-    const id = item.id ?? Date.now() + Math.random();
+    const id = item.id ?? uuid();
     setItems((prev) => {
       const existing = prev.find((i) => i.id === id);
       if (existing) {

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid';
+
 export let mockEvents = [
   {
     id: '1',
@@ -135,7 +137,7 @@ export const mockFetchBookings = async () => {
 
 export const mockCreateEvent = async (data) => {
   loadMock();
-  const newEvent = { id: Date.now().toString(), ...data };
+  const newEvent = { id: uuid(), ...data };
   mockEvents.push(newEvent);
   save();
   return newEvent;
@@ -150,7 +152,7 @@ export const mockDeleteEvent = async (id) => {
 
 export const mockSendBooking = async (data) => {
   loadMock();
-  const newBooking = { id: Date.now().toString(), ...data };
+  const newBooking = { id: uuid(), ...data };
   mockBookings.push(newBooking);
   save();
   return newBooking;


### PR DESCRIPTION
## Summary
- add `uuid` dependency
- use `uuid` to generate IDs in `mockApi`
- use `uuid` for cart item IDs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68558741499883249c40b976a87fca77