### PR TITLE
Add gallery upload management

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -81,7 +81,43 @@ app.get('/api/bookings', async (req, res) => {
     res.json(data);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to load bookings' });
+  res.status(500).json({ error: 'Failed to load bookings' });
+  }
+});
+
+// Retrieve gallery images
+app.get('/api/gallery', async (req, res) => {
+  try {
+    const snapshot = await db.collection('gallery').orderBy('createdAt', 'desc').get();
+    const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to load gallery' });
+  }
+});
+
+// Add an image to the gallery
+app.post('/api/gallery', async (req, res) => {
+  const { src } = req.body;
+  if (!src) return res.status(400).json({ error: 'Missing src' });
+  try {
+    const doc = await db.collection('gallery').add({ src, createdAt: new Date() });
+    res.json({ id: doc.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to save image' });
+  }
+});
+
+// Delete an image from the gallery
+app.delete('/api/gallery/:id', async (req, res) => {
+  try {
+    await db.collection('gallery').doc(req.params.id).delete();
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete image' });
   }
 });
 

--- a/src/api.js
+++ b/src/api.js
@@ -50,3 +50,28 @@ export const deleteEvent = async (id) => {
   if (!res.ok) throw new Error('Failed to delete event');
   return res.json();
 };
+
+export const fetchGallery = async () => {
+  if (useMock) return [];
+  const res = await fetch('/api/gallery');
+  if (!res.ok) throw new Error('Failed to load gallery');
+  return res.json();
+};
+
+export const uploadGalleryImage = async (src) => {
+  if (useMock) return { id: Date.now().toString(), src };
+  const res = await fetch('/api/gallery', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ src }),
+  });
+  if (!res.ok) throw new Error('Failed to save image');
+  return res.json();
+};
+
+export const deleteGalleryImage = async (id) => {
+  if (useMock) return { success: true };
+  const res = await fetch(`/api/gallery/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete image');
+  return res.json();
+};


### PR DESCRIPTION
## Summary
- allow saving images to gallery collection on backend
- expose new gallery API helpers in frontend
- add gallery section in admin panel for uploading & deleting images

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855db25d80883249b94c9fff6d635f0