### PR TITLE
Add Firestore setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Run the API server with:
 npm run server
 ```
 
+After configuring Firebase credentials you can create the required Firestore collections with:
+
+```bash
+cd server
+npm run setup
+```
+
 Visita `/prenota` per il form di prenotazione dei biglietti collegato a Firebase.
 
 ## Area admin

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "setup": "node setupFirestore.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/server/setupFirestore.js
+++ b/server/setupFirestore.js
@@ -1,0 +1,37 @@
+import { db } from './firebase.js';
+
+async function setup() {
+  const now = new Date();
+  // Create sample event
+  await db.collection('events').doc('sample').set({
+    name: 'Sample Event',
+    dj: 'DJ Test',
+    date: '2025-01-01',
+    place: 'Online',
+    time: '00:00',
+    price: '',
+    image: '',
+    description: 'Example document',
+  });
+  // Create sample booking
+  await db.collection('bookings').doc('sample').set({
+    nome: 'Example',
+    cognome: 'User',
+    email: 'example@example.com',
+    telefono: '0000000000',
+    createdAt: now,
+  });
+  // Create sample gallery image
+  await db.collection('gallery').doc('sample').set({
+    src: 'https://example.com/image.jpg',
+    createdAt: now,
+  });
+}
+
+setup().then(() => {
+  console.log('Firestore collections initialized');
+  process.exit(0);
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -5,9 +5,9 @@ import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBqtP0z6qos7M55gPn_WqCjlgApHhSrC28",
-  authDomain: '"djscovery-47610.firebaseapp.com',
+  authDomain: "djscovery-47610.firebaseapp.com",
   projectId: "djscovery-47610",
-  storageBucket: "djscovery-47610.firebasestorage.app",
+  storageBucket: "djscovery-47610.appspot.com",
   messagingSenderId: "547949192479",
   appId: "1:547949192479:web:4231be05c2cf2e548d7c2a",
 };


### PR DESCRIPTION
## Summary
- fix firebase config typos
- add script to create initial Firestore collections
- document setup script in README

## Testing
- `npm run setup` *(fails: Unable to detect a Project Id)*
- `npm run server` *(starts Express server on port 3000)*

------
https://chatgpt.com/codex/tasks/task_e_68591098179c8324a9e38031d52fbe95