### PR TITLE
Enhance Firebase credential setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pubblica.
 npm install firebase
 ```
 
-Il file `server/index.js` espone l'endpoint `POST /api/bookings` che salva i dati nella collezione `bookings` di Firestore tramite Firebase Admin. Imposta la variabile `GOOGLE_APPLICATION_CREDENTIALS` con il percorso del tuo service account.
+Il file `server/index.js` espone l'endpoint `POST /api/bookings` che salva i dati nella collezione `bookings` di Firestore tramite Firebase Admin. Per autenticare il server imposta la variabile d'ambiente `FIREBASE_SERVICE_ACCOUNT` (o `GOOGLE_APPLICATION_CREDENTIALS`) con il percorso del tuo file JSON di servizio.
 È inoltre disponibile l'endpoint `GET /api/events` che restituisce l'elenco degli eventi.
 
 ## Deploy dell'applicazione

--- a/server/firebase.js
+++ b/server/firebase.js
@@ -1,8 +1,19 @@
-import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+
+const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+let credential;
+if (serviceAccountPath) {
+  const serviceAccount = JSON.parse(readFileSync(serviceAccountPath, 'utf8'));
+  credential = cert(serviceAccount);
+} else {
+  credential = applicationDefault();
+}
 
 initializeApp({
-  credential: applicationDefault(),
+  credential,
 });
 
 export const db = getFirestore();


### PR DESCRIPTION
## Summary
- allow specifying Firebase service account path via environment variables
- document how to use the new `FIREBASE_SERVICE_ACCOUNT` variable

## Testing
- `npm run build`
- `node -e "import './server/firebase.js'; console.log('loaded')"`
- `npm run setup` *(fails: Unable to detect a Project Id)*

------
https://chatgpt.com/codex/tasks/task_e_68592c757e748324a269bf99f4f4dbf3