### PR TITLE
Rimuove parallax e migliora slider

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.21.1",
     "react-swipeable": "^7.0.2",
-    "react-parallax": "^3.5.2",
     "styled-components": "^6.1.1",
     "swiper": "^11.2.8",
     "uuid": "^11.1.0"

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -19,7 +19,7 @@ const Section = styled(motion.section)`
 const Background = styled(motion.div)`
   position: absolute;
   inset: 0;
-  background-size: contain;
+  background-size: cover;
   background-repeat: no-repeat;
   background-position: center;
   transform-origin: center;

--- a/src/components/HomeGallerySlider.jsx
+++ b/src/components/HomeGallerySlider.jsx
@@ -21,16 +21,16 @@ const Section = styled.section`
 
 const SlideImage = styled.img`
   width: 100%;
-  height: 220px;
+  height: 180px;
   object-fit: cover;
   border-radius: 8px;
 
   @media (min-width: 768px) {
-    height: 300px;
+    height: 220px;
   }
 
   @media (min-width: 1024px) {
-    height: 350px;
+    height: 250px;
   }
 `;
 
@@ -44,6 +44,12 @@ const HomeGallerySlider = () => (
         pagination={{ clickable: true }}
         autoplay={{ delay: 3000 }}
         loop
+        slidesPerView={1}
+        spaceBetween={10}
+        breakpoints={{
+          768: { slidesPerView: 2 },
+          1024: { slidesPerView: 3 },
+        }}
         style={{ borderRadius: "8px" }}
       >
         {images.map((src, idx) => (

--- a/src/components/NewsletterSection.jsx
+++ b/src/components/NewsletterSection.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { motion } from "framer-motion";
-import { Parallax } from "react-parallax";
 import { useLanguage } from "./LanguageContext";
 import { FaPaperPlane } from "react-icons/fa";
 import { useToast } from "./ToastContext";
@@ -13,6 +12,9 @@ const Section = styled.section`
   color: var(--white);
   text-align: center;
   overflow: hidden;
+  background-image: url(${heroImg});
+  background-size: cover;
+  background-position: center;
 `;
 
 const Overlay = styled.div`
@@ -71,10 +73,9 @@ const NewsletterSection = () => {
   };
 
   return (
-    <Parallax bgImage={heroImg} strength={200} bgImageAlt="newsletter">
-      <Section>
-        <Overlay />
-        <Content className="container">
+    <Section>
+      <Overlay />
+      <Content className="container">
           <h2>{t("newsletter.title")}</h2>
           <p>{t("newsletter.subtitle")}</p>
           <Form onSubmit={handleSubmit}>
@@ -93,9 +94,8 @@ const NewsletterSection = () => {
             </Button>
           </Form>
           {/* success handled via toast */}
-        </Content>
-      </Section>
-    </Parallax>
+      </Content>
+    </Section>
   );
 };
 


### PR DESCRIPTION
## Summary
- remove `react-parallax` usage and dependency
- adjust newsletter section with static background
- tweak hero background to use `cover`
- make home gallery slider show multiple slides per view

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68595db08e9483248a039089f9ce9ba3