### PR TITLE
Fix admin event creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ pubblica. Per utilizzare la selezione di immagini da Google Drive configura anch
 `VITE_GOOGLE_CLIENT_ID` e `VITE_GOOGLE_API_KEY` con le credenziali del tuo
  progetto Google.
 
+Se il server API è in esecuzione su un dominio o porta diversa è possibile
+specificarlo impostando la variabile `VITE_API_BASE_URL` nel file `.env`.
+In questo modo tutte le richieste verranno indirizzate correttamente al backend.
+
 Le immagini caricate nella sezione Gallery del pannello verranno mostrate
 nella pagina pubblica "/gallery" insieme a quelle predefinite.
 

--- a/src/api.js
+++ b/src/api.js
@@ -10,17 +10,18 @@ import {
 } from './mockApi';
 
 const useMock = import.meta.env.VITE_MOCK !== 'false';
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
 export const fetchEvents = async () => {
   if (useMock) return mockFetchEvents();
-  const res = await fetch('/api/events');
+  const res = await fetch(`${API_BASE}/api/events`);
   if (!res.ok) throw new Error('Failed to load events');
   return res.json();
 };
 
 export const sendBooking = async (data) => {
   if (useMock) return mockSendBooking(data);
-  const res = await fetch('/api/bookings', {
+  const res = await fetch(`${API_BASE}/api/bookings`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -31,14 +32,14 @@ export const sendBooking = async (data) => {
 
 export const fetchBookings = async () => {
   if (useMock) return mockFetchBookings();
-  const res = await fetch('/api/bookings');
+  const res = await fetch(`${API_BASE}/api/bookings`);
   if (!res.ok) throw new Error('Failed to load bookings');
   return res.json();
 };
 
 export const createEvent = async (data) => {
   if (useMock) return mockCreateEvent(data);
-  const res = await fetch('/api/events', {
+  const res = await fetch(`${API_BASE}/api/events`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -49,21 +50,21 @@ export const createEvent = async (data) => {
 
 export const deleteEvent = async (id) => {
   if (useMock) return mockDeleteEvent(id);
-  const res = await fetch(`/api/events/${id}`, { method: 'DELETE' });
+  const res = await fetch(`${API_BASE}/api/events/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete event');
   return res.json();
 };
 
 export const fetchGallery = async () => {
   if (useMock) return mockFetchGallery();
-  const res = await fetch('/api/gallery');
+  const res = await fetch(`${API_BASE}/api/gallery`);
   if (!res.ok) throw new Error('Failed to load gallery');
   return res.json();
 };
 
 export const uploadGalleryImage = async (src) => {
   if (useMock) return mockUploadGalleryImage(src);
-  const res = await fetch('/api/gallery', {
+  const res = await fetch(`${API_BASE}/api/gallery`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ src }),
@@ -74,7 +75,7 @@ export const uploadGalleryImage = async (src) => {
 
 export const deleteGalleryImage = async (id) => {
   if (useMock) return mockDeleteGalleryImage(id);
-  const res = await fetch(`/api/gallery/${id}`, { method: 'DELETE' });
+  const res = await fetch(`${API_BASE}/api/gallery/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete image');
   return res.json();
 };

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -144,6 +144,7 @@ const AdminPanel = () => {
     const reader = new FileReader();
     reader.onloadend = () => {
       setFormData((f) => ({ ...f, image: reader.result }));
+      showToast('Immagine caricata', 'success');
     };
     reader.readAsDataURL(file);
   };


### PR DESCRIPTION
## Summary
- set `VITE_API_BASE_URL` to target backend server
- notify admins when an image loads for an event

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685962171010832497277e41acb4ea41