### PR TITLE
Configure backend env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ cd ..
 npm run server
 ```
 
+Create a `.env` file inside the `server` directory by copying `.env.example` and
+set your backend configuration values (e.g. `PORT`, `FIREBASE_SERVICE_ACCOUNT` or
+`GOOGLE_APPLICATION_CREDENTIALS`, and `FIREBASE_PROJECT_ID`) before starting the
+API server.
+
 After configuring Firebase credentials you can create the required Firestore collections with:
 
 ```bash

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+FIREBASE_SERVICE_ACCOUNT=path/to/serviceAccount.json
+# Alternatively you can set GOOGLE_APPLICATION_CREDENTIALS
+FIREBASE_PROJECT_ID=your-project-id

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import { db } from './firebase.js';

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "firebase-admin": "^11.10.1"
+    "firebase-admin": "^11.10.1",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- explain the new missing backend configuration and where to add the env file
- load environment variables for the server
- add dotenv to backend dependencies
- include an example env file

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685966540f548324acf5abd640746294