### PR TITLE
Improve admin panel responsiveness and Drive integration

### DIFF
--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -31,6 +31,7 @@ import {
   TableBody,
   Divider,
   IconButton,
+  Grid,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -66,7 +67,6 @@ const AdminPanel = () => {
   const [gallery, setGallery] = useState([]);
   const [gallerySrc, setGallerySrc] = useState('');
   const [pickerLoaded, setPickerLoaded] = useState(false);
-  const [oauthToken, setOauthToken] = useState('');
   const [formData, setFormData] = useState({
     name: '',
     dj: '',
@@ -104,8 +104,16 @@ const AdminPanel = () => {
     if (window.gapi) {
       onLoad();
     } else {
-      const script = document.querySelector('script[src="https://apis.google.com/js/api.js"]');
-      if (script) script.addEventListener('load', onLoad);
+      const src = 'https://apis.google.com/js/api.js';
+      let script = document.querySelector(`script[src="${src}"]`);
+      if (!script) {
+        script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        document.body.appendChild(script);
+      }
+      script.addEventListener('load', onLoad);
+      return () => script.removeEventListener('load', onLoad);
     }
   }, []);
 
@@ -166,7 +174,6 @@ const AdminPanel = () => {
     try {
       const auth = await window.gapi.auth2.getAuthInstance().signIn();
       const token = auth.getAuthResponse().access_token;
-      setOauthToken(token);
       const view = new window.google.picker.DocsView(window.google.picker.ViewId.DOCS_IMAGES)
         .setMimeTypes('image/png,image/jpeg,image/jpg');
       const picker = new window.google.picker.PickerBuilder()
@@ -394,63 +401,90 @@ const handleGallerySubmit = async (e) => {
           </Box>
         )}
         {section === 'create' && (
-          <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: isMobile ? '100%' : 400, width: '100%' }}>
-            <Typography variant="h5" gutterBottom>
-              Crea Evento
-            </Typography>
-            <TextField name="name" label="Nome Evento" variant="outlined" value={formData.name} onChange={handleChange} fullWidth />
-            <TextField name="dj" label="DJ" variant="outlined" value={formData.dj} onChange={handleChange} fullWidth />
-            <TextField type="date" name="date" label="Data" InputLabelProps={{ shrink: true }} variant="outlined" value={formData.date} onChange={handleChange} fullWidth />
-            <Autocomplete
-              freeSolo
-              options={placeOptions}
-              inputValue={formData.place}
-              onInputChange={(e, value) => setFormData({ ...formData, place: value })}
-              renderInput={(params) => (
-                <TextField {...params} label="Luogo" variant="outlined" fullWidth />
-              )}
-            />
-            <TextField type="time" name="time" label="Orario" InputLabelProps={{ shrink: true }} variant="outlined" value={formData.time} onChange={handleChange} fullWidth />
-            <TextField name="price" label="Prezzo" variant="outlined" value={formData.price} onChange={handleChange} fullWidth />
-            <Button variant="outlined" component="label" sx={{ color: 'var(--yellow)', borderColor: 'var(--yellow)' }}>
-              Carica Immagine
-              <input type="file" hidden accept="image/*" onChange={handleFile} />
-            </Button>
-            <TextField name="description" label="Descrizione" variant="outlined" value={formData.description} onChange={handleChange} fullWidth />
-            <Button type="submit" variant="contained" fullWidth={isMobile}
-              sx={{ alignSelf: isMobile ? 'stretch' : 'flex-start', backgroundColor: 'var(--red)', '&:hover': { backgroundColor: '#c62828' } }}>
-              Crea
-            </Button>
-          </Box>
+          <Grid container component="form" onSubmit={handleSubmit} spacing={2} sx={{ maxWidth: 600, width: '100%' }}>
+            <Grid item xs={12}>
+              <Typography variant="h5" gutterBottom>
+                Crea Evento
+              </Typography>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField name="name" label="Nome Evento" variant="outlined" value={formData.name} onChange={handleChange} fullWidth />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField name="dj" label="DJ" variant="outlined" value={formData.dj} onChange={handleChange} fullWidth />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField type="date" name="date" label="Data" InputLabelProps={{ shrink: true }} variant="outlined" value={formData.date} onChange={handleChange} fullWidth />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Autocomplete
+                freeSolo
+                options={placeOptions}
+                inputValue={formData.place}
+                onInputChange={(e, value) => setFormData({ ...formData, place: value })}
+                renderInput={(params) => (
+                  <TextField {...params} label="Luogo" variant="outlined" fullWidth />
+                )}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField type="time" name="time" label="Orario" InputLabelProps={{ shrink: true }} variant="outlined" value={formData.time} onChange={handleChange} fullWidth />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField name="price" label="Prezzo" variant="outlined" value={formData.price} onChange={handleChange} fullWidth />
+            </Grid>
+            <Grid item xs={12}>
+              <Button variant="outlined" component="label" sx={{ color: 'var(--yellow)', borderColor: 'var(--yellow)' }}>
+                Carica Immagine
+                <input type="file" hidden accept="image/*" onChange={handleFile} />
+              </Button>
+            </Grid>
+            <Grid item xs={12}>
+              <TextField name="description" label="Descrizione" variant="outlined" value={formData.description} onChange={handleChange} fullWidth />
+            </Grid>
+            <Grid item xs={12}>
+              <Button type="submit" variant="contained" fullWidth={isMobile} sx={{ backgroundColor: 'var(--red)', '&:hover': { backgroundColor: '#c62828' } }}>
+                Crea
+              </Button>
+            </Grid>
+          </Grid>
         )}
         {section === 'gallery' && (
-          <Box component="form" onSubmit={handleGallerySubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: isMobile ? '100%' : 400, width: '100%' }}>
-            <Typography variant="h5" gutterBottom>
-              Gallery
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button variant="outlined" component="label" sx={{ color: 'var(--yellow)', borderColor: 'var(--yellow)' }}>
+          <Grid container component="form" onSubmit={handleGallerySubmit} spacing={2} sx={{ maxWidth: isMobile ? '100%' : 400, width: '100%' }}>
+            <Grid item xs={12}>
+              <Typography variant="h5" gutterBottom>
+                Gallery
+              </Typography>
+            </Grid>
+            <Grid item xs={6}>
+              <Button variant="outlined" component="label" fullWidth sx={{ color: 'var(--yellow)', borderColor: 'var(--yellow)' }}>
                 Carica Immagine
                 <input type="file" hidden accept="image/*" onChange={handleGalleryFile} />
               </Button>
-              <Button variant="outlined" onClick={pickFromDrive} sx={{ color: 'var(--yellow)', borderColor: 'var(--yellow)' }}>
+            </Grid>
+            <Grid item xs={6}>
+              <Button variant="outlined" onClick={pickFromDrive} fullWidth sx={{ color: 'var(--yellow)', borderColor: 'var(--yellow)' }}>
                 <AddToDriveIcon />
               </Button>
-            </Box>
-            <Button type="submit" variant="contained" sx={{ backgroundColor: 'var(--red)', '&:hover': { backgroundColor: '#c62828' } }}>
-              Aggiungi
-            </Button>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 2 }}>
-              {gallery.map((img) => (
-                <Box key={img.id} sx={{ position: 'relative' }}>
-                  <img src={img.src} alt="gallery" style={{ width: 100, height: 100, objectFit: 'cover' }} />
-                  <IconButton size="small" color="error" sx={{ position: 'absolute', top: 0, right: 0 }} onClick={() => setConfirm({ open: true, id: img.id, type: 'image' })}>
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Box>
-              ))}
-            </Box>
-          </Box>
+            </Grid>
+            <Grid item xs={12}>
+              <Button type="submit" variant="contained" fullWidth sx={{ backgroundColor: 'var(--red)', '&:hover': { backgroundColor: '#c62828' } }}>
+                Aggiungi
+              </Button>
+            </Grid>
+            <Grid item xs={12}>
+              <Grid container spacing={1}>
+                {gallery.map((img) => (
+                  <Grid item key={img.id} xs={4} sm={3} md={2} sx={{ position: 'relative' }}>
+                    <img src={img.src} alt="gallery" style={{ width: '100%', height: 100, objectFit: 'cover' }} />
+                    <IconButton size="small" color="error" sx={{ position: 'absolute', top: 0, right: 0 }} onClick={() => setConfirm({ open: true, id: img.id, type: 'image' })}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Grid>
+                ))}
+              </Grid>
+            </Grid>
+          </Grid>
         )}
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- enhance Google Drive picker loading logic
- make event creation and gallery forms responsive with MUI Grid
- cleanup unused OAuth token logic

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68596c99c8c08324aa9cc83d2d2868f6