### PR TITLE
Migliora login admin e icona sulla home

### DIFF
--- a/src/components/AdminLogin.jsx
+++ b/src/components/AdminLogin.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Button, Paper, TextField, Typography } from '@mui/material';
 
@@ -6,6 +6,12 @@ const AdminLogin = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (localStorage.getItem('isAdmin') === 'true') {
+      navigate('/admin/panel');
+    }
+  }, [navigate]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -19,7 +25,16 @@ const AdminLogin = () => {
   };
 
   return (
-    <Box sx={{ textAlign: 'center', minHeight: 'calc(100vh - 200px)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Box
+      sx={{
+        textAlign: 'center',
+        minHeight: 'calc(100vh - 200px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: 2,
+      }}
+    >
       <Paper
         component="form"
         onSubmit={handleSubmit}
@@ -32,7 +47,7 @@ const AdminLogin = () => {
           maxWidth: 400,
           backgroundColor: 'rgba(0,0,0,0.3)',
           boxShadow: '0 2px 8px rgba(0,0,0,0.4)',
-          borderRadius: 3
+          borderRadius: 3,
         }}
       >
         <Typography variant="h5" gutterBottom>

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -333,10 +333,10 @@ const handleGallerySubmit = async (e) => {
       >
         {drawer}
       </Drawer>
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }} className="container">
         <Toolbar />
         {section === 'bookings' && (
-          <Paper sx={{ p: 2, mb: 3, boxShadow: 3 }}>
+          <Paper sx={{ p: 3, mb: 4, boxShadow: 3, overflowX: 'auto' }}>
             <Typography variant="h5" gutterBottom>
               Prenotazioni
             </Typography>
@@ -367,7 +367,7 @@ const handleGallerySubmit = async (e) => {
           </Paper>
         )}
         {section === 'events' && (
-          <Paper sx={{ p: 2, mb: 3, boxShadow: 3 }}>
+          <Paper sx={{ p: 3, mb: 4, boxShadow: 3, overflowX: 'auto' }}>
             <Typography variant="h5" gutterBottom>
               Eventi
             </Typography>
@@ -404,8 +404,8 @@ const handleGallerySubmit = async (e) => {
           </Paper>
         )}
         {section === 'create' && (
-          <Paper sx={{ p: 2, mb: 3, boxShadow: 3 }}>
-          <Grid container direction="column" component="form" onSubmit={handleSubmit} spacing={2} sx={{ maxWidth: 600, width: '100%' }}>
+          <Paper sx={{ p: 3, mb: 4, boxShadow: 3, maxWidth: 600, mx: 'auto' }}>
+          <Grid container direction="column" component="form" onSubmit={handleSubmit} spacing={2}>
             <Grid item xs={12}>
               <Typography variant="h5" gutterBottom>
                 Crea Evento
@@ -455,8 +455,8 @@ const handleGallerySubmit = async (e) => {
           </Paper>
         )}
         {section === 'gallery' && (
-          <Paper sx={{ p: 2, mb: 3, boxShadow: 3 }}>
-          <Grid container direction="column" component="form" onSubmit={handleGallerySubmit} spacing={2} sx={{ maxWidth: isMobile ? '100%' : 400, width: '100%' }}>
+          <Paper sx={{ p: 3, mb: 4, boxShadow: 3, maxWidth: isMobile ? '100%' : 400, mx: 'auto' }}>
+          <Grid container direction="column" component="form" onSubmit={handleGallerySubmit} spacing={2}>
             <Grid item xs={12}>
               <Typography variant="h5" gutterBottom>
                 Gallery

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -1,10 +1,26 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import styled from 'styled-components';
+import { FaUserCircle } from 'react-icons/fa';
 import HeroSection from './HeroSection';
 import HomeGallerySlider from './HomeGallerySlider';
 import NewsletterSection from './NewsletterSection';
 
+const LoginLink = styled(motion(Link))`
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  font-size: 2rem;
+  color: var(--yellow);
+  z-index: 1500;
+`;
+
 const HomePage = () => (
   <>
+    <LoginLink to="/admin" whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }} aria-label="Admin login">
+      <FaUserCircle />
+    </LoginLink>
     <HeroSection />
     <HomeGallerySlider />
     <NewsletterSection />


### PR DESCRIPTION
## Summary
- redirect logged admin to the panel
- tidy up admin login layout
- show a fixed login icon on home page
- center content on admin panel and improve spacing

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685aa45ed2cc8324a93096e5f6b0fd66