### PR TITLE
Add home button to admin login

### DIFF
--- a/src/components/AdminLogin.jsx
+++ b/src/components/AdminLogin.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Box, Button, Paper, TextField, Typography } from '@mui/material';
+import { useLanguage } from './LanguageContext';
 import { signInWithEmailAndPassword, onAuthStateChanged } from 'firebase/auth';
 import logo from '../assets/img/ADMIN.png';
 import heroImg from '../assets/img/hero.png';
@@ -11,6 +12,7 @@ const AdminLogin = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
+  const { t } = useLanguage();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -108,6 +110,14 @@ const AdminLogin = () => {
             {error}
           </Typography>
         )}
+        <Button
+          component={Link}
+          to="/"
+          variant="outlined"
+          sx={{ mt: 1, color: 'var(--yellow)', borderColor: 'var(--yellow)' }}
+        >
+          {t('nav.home')}
+        </Button>
       </Paper>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add LanguageContext & Link imports
- add `t` translation hook
- add a "Home" button in `AdminLogin`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685aba65f22c8324bc4c332ab6854c4a