### PR TITLE
Add Brevo newsletter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ npm run server
 Create a `.env` file inside the `server` directory by copying `.env.example` and
 set your backend configuration values (e.g. `PORT`, `FIREBASE_SERVICE_ACCOUNT` or
 `GOOGLE_APPLICATION_CREDENTIALS`, and `FIREBASE_PROJECT_ID`) before starting the
-API server.
+API server. To enable newsletter subscriptions via Brevo, configure also
+`BREVO_API_KEY` and `BREVO_LIST_ID` with your account details.
 
 After configuring Firebase credentials you can create the required Firestore collections with:
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,5 @@ FIREBASE_SERVICE_ACCOUNT=path/to/serviceAccount.json
 # Alternatively you can set GOOGLE_APPLICATION_CREDENTIALS
 FIREBASE_PROJECT_ID=your-project-id
 ADMIN_PASSWORD=admin
+BREVO_API_KEY=your-brevo-api-key
+BREVO_LIST_ID=0

--- a/server/index.js
+++ b/server/index.js
@@ -1,52 +1,52 @@
-import 'dotenv/config';
-import express from 'express';
-import cors from 'cors';
-import { db } from './firebase.js';
+import "dotenv/config";
+import express from "express";
+import cors from "cors";
+import { db } from "./firebase.js";
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 // Simple admin login
-app.post('/api/login', (req, res) => {
+app.post("/api/login", (req, res) => {
   const { password } = req.body;
-  const expected = process.env.ADMIN_PASSWORD || 'admin';
+  const expected = process.env.ADMIN_PASSWORD || "admin";
   if (password === expected) return res.json({ success: true });
-  res.status(401).json({ error: 'Unauthorized' });
+  res.status(401).json({ error: "Unauthorized" });
 });
 
 // Get all events
-app.get('/api/events', async (_req, res) => {
+app.get("/api/events", async (_req, res) => {
   try {
-    const snapshot = await db.collection('events').get();
+    const snapshot = await db.collection("events").get();
     const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
     res.json(data);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to load events' });
+    res.status(500).json({ error: "Failed to load events" });
   }
 });
 
 // Get single event
-app.get('/api/events/:id', async (req, res) => {
+app.get("/api/events/:id", async (req, res) => {
   try {
-    const doc = await db.collection('events').doc(req.params.id).get();
-    if (!doc.exists) return res.status(404).json({ error: 'Not found' });
+    const doc = await db.collection("events").doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: "Not found" });
     res.json({ id: doc.id, ...doc.data() });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to load event' });
+    res.status(500).json({ error: "Failed to load event" });
   }
 });
 
 // Create a new event
-app.post('/api/events', async (req, res) => {
+app.post("/api/events", async (req, res) => {
   const { name, dj, date, place, time, price, image, description } = req.body;
   if (!name || !dj || !date || !place || !time || !image) {
-    return res.status(400).json({ error: 'Missing fields' });
+    return res.status(400).json({ error: "Missing fields" });
   }
   try {
-    const doc = await db.collection('events').add({
+    const doc = await db.collection("events").add({
       name,
       dj,
       date,
@@ -59,15 +59,15 @@ app.post('/api/events', async (req, res) => {
     res.json({ id: doc.id });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to create event' });
+    res.status(500).json({ error: "Failed to create event" });
   }
 });
 
 // Update an event
-app.put('/api/events/:id', async (req, res) => {
+app.put("/api/events/:id", async (req, res) => {
   const { name, dj, date, place, time, price, image, description } = req.body;
   try {
-    await db.collection('events').doc(req.params.id).update({
+    await db.collection("events").doc(req.params.id).update({
       name,
       dj,
       date,
@@ -80,28 +80,28 @@ app.put('/api/events/:id', async (req, res) => {
     res.json({ success: true });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to update event' });
+    res.status(500).json({ error: "Failed to update event" });
   }
 });
 
 // Delete an event
-app.delete('/api/events/:id', async (req, res) => {
+app.delete("/api/events/:id", async (req, res) => {
   try {
-    await db.collection('events').doc(req.params.id).delete();
+    await db.collection("events").doc(req.params.id).delete();
     res.json({ success: true });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to delete event' });
+    res.status(500).json({ error: "Failed to delete event" });
   }
 });
 
-app.post('/api/bookings', async (req, res) => {
+app.post("/api/bookings", async (req, res) => {
   const { nome, cognome, email, telefono } = req.body;
   if (!nome || !cognome || !email || !telefono) {
-    return res.status(400).json({ error: 'Missing fields' });
+    return res.status(400).json({ error: "Missing fields" });
   }
   try {
-    await db.collection('bookings').add({
+    await db.collection("bookings").add({
       nome,
       cognome,
       email,
@@ -111,78 +111,124 @@ app.post('/api/bookings', async (req, res) => {
     res.json({ success: true });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to save booking' });
+    res.status(500).json({ error: "Failed to save booking" });
   }
 });
 
 // Retrieve all bookings
-app.get('/api/bookings', async (_req, res) => {
+app.get("/api/bookings", async (_req, res) => {
   try {
-    const snapshot = await db.collection('bookings').orderBy('createdAt', 'desc').get();
+    const snapshot = await db
+      .collection("bookings")
+      .orderBy("createdAt", "desc")
+      .get();
     const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
     res.json(data);
   } catch (err) {
     console.error(err);
-  res.status(500).json({ error: 'Failed to load bookings' });
+    res.status(500).json({ error: "Failed to load bookings" });
   }
 });
 
 // Retrieve gallery images
-app.get('/api/gallery', async (req, res) => {
+app.get("/api/gallery", async (req, res) => {
   try {
-    const snapshot = await db.collection('gallery').orderBy('createdAt', 'desc').get();
+    const snapshot = await db
+      .collection("gallery")
+      .orderBy("createdAt", "desc")
+      .get();
     const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
     res.json(data);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to load gallery' });
+    res.status(500).json({ error: "Failed to load gallery" });
   }
 });
 
 // Add an image to the gallery
-app.post('/api/gallery', async (req, res) => {
+app.post("/api/gallery", async (req, res) => {
   const { src } = req.body;
-  if (!src) return res.status(400).json({ error: 'Missing src' });
+  if (!src) return res.status(400).json({ error: "Missing src" });
   try {
-    const doc = await db.collection('gallery').add({ src, createdAt: new Date() });
+    const doc = await db
+      .collection("gallery")
+      .add({ src, createdAt: new Date() });
     res.json({ id: doc.id });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to save image' });
+    res.status(500).json({ error: "Failed to save image" });
   }
 });
 
 // Delete an image from the gallery
-app.delete('/api/gallery/:id', async (req, res) => {
+app.delete("/api/gallery/:id", async (req, res) => {
   try {
-    await db.collection('gallery').doc(req.params.id).delete();
+    await db.collection("gallery").doc(req.params.id).delete();
     res.json({ success: true });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to delete image' });
+    res.status(500).json({ error: "Failed to delete image" });
   }
 });
 
 // Get a single booking
-app.get('/api/bookings/:id', async (req, res) => {
+app.get("/api/bookings/:id", async (req, res) => {
   try {
-    const doc = await db.collection('bookings').doc(req.params.id).get();
-    if (!doc.exists) return res.status(404).json({ error: 'Not found' });
+    const doc = await db.collection("bookings").doc(req.params.id).get();
+    if (!doc.exists) return res.status(404).json({ error: "Not found" });
     res.json({ id: doc.id, ...doc.data() });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to load booking' });
+    res.status(500).json({ error: "Failed to load booking" });
   }
 });
 
 // Delete a booking
-app.delete('/api/bookings/:id', async (req, res) => {
+app.delete("/api/bookings/:id", async (req, res) => {
   try {
-    await db.collection('bookings').doc(req.params.id).delete();
+    await db.collection("bookings").doc(req.params.id).delete();
     res.json({ success: true });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to delete booking' });
+    res.status(500).json({ error: "Failed to delete booking" });
+  }
+});
+
+// Subscribe to newsletter via Brevo
+app.post("/api/newsletter", async (req, res) => {
+  const { email } = req.body;
+  if (!email) return res.status(400).json({ error: "Missing email" });
+
+  const apiKey = process.env.BREVO_API_KEY;
+  const listId = process.env.BREVO_LIST_ID;
+  if (!apiKey || !listId) {
+    return res.status(500).json({ error: "Brevo not configured" });
+  }
+
+  try {
+    const resp = await fetch("https://api.brevo.com/v3/contacts", {
+      method: "POST",
+      headers: {
+        "api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email,
+        listIds: [Number(listId)],
+        updateEnabled: true,
+      }),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error("Brevo error:", text);
+      return res.status(500).json({ error: "Failed to subscribe" });
+    }
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to subscribe" });
   }
 });
 

--- a/src/api.js
+++ b/src/api.js
@@ -7,24 +7,26 @@ import {
   mockFetchGallery,
   mockUploadGalleryImage,
   mockDeleteGalleryImage,
-} from './mockApi';
-import { withLoading } from './loading';
+  mockSubscribeNewsletter,
+} from "./mockApi";
+import { withLoading } from "./loading";
 
-const useMock = import.meta.env.VITE_MOCK !== 'false';
-const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+const useMock = import.meta.env.VITE_MOCK !== "false";
+const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
 
 export const login = async (password) => {
   if (useMock) {
-    if (password === (import.meta.env.VITE_ADMIN_PASSWORD || 'admin')) return { success: true };
-    throw new Error('Invalid password');
+    if (password === (import.meta.env.VITE_ADMIN_PASSWORD || "admin"))
+      return { success: true };
+    throw new Error("Invalid password");
   }
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ password }),
     });
-    if (!res.ok) throw new Error('Invalid password');
+    if (!res.ok) throw new Error("Invalid password");
     return res.json();
   });
 };
@@ -33,7 +35,7 @@ export const fetchEvents = async () => {
   if (useMock) return mockFetchEvents();
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/events`);
-    if (!res.ok) throw new Error('Failed to load events');
+    if (!res.ok) throw new Error("Failed to load events");
     return res.json();
   });
 };
@@ -42,11 +44,11 @@ export const sendBooking = async (data) => {
   if (useMock) return mockSendBooking(data);
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/bookings`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     });
-    if (!res.ok) throw new Error('Failed to save booking');
+    if (!res.ok) throw new Error("Failed to save booking");
     return res.json();
   });
 };
@@ -55,7 +57,7 @@ export const fetchBookings = async () => {
   if (useMock) return mockFetchBookings();
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/bookings`);
-    if (!res.ok) throw new Error('Failed to load bookings');
+    if (!res.ok) throw new Error("Failed to load bookings");
     return res.json();
   });
 };
@@ -64,11 +66,11 @@ export const createEvent = async (data) => {
   if (useMock) return mockCreateEvent(data);
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/events`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     });
-    if (!res.ok) throw new Error('Failed to create event');
+    if (!res.ok) throw new Error("Failed to create event");
     return res.json();
   });
 };
@@ -76,8 +78,10 @@ export const createEvent = async (data) => {
 export const deleteEvent = async (id) => {
   if (useMock) return mockDeleteEvent(id);
   return withLoading(async () => {
-    const res = await fetch(`${API_BASE}/api/events/${id}`, { method: 'DELETE' });
-    if (!res.ok) throw new Error('Failed to delete event');
+    const res = await fetch(`${API_BASE}/api/events/${id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) throw new Error("Failed to delete event");
     return res.json();
   });
 };
@@ -86,7 +90,7 @@ export const fetchGallery = async () => {
   if (useMock) return mockFetchGallery();
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/gallery`);
-    if (!res.ok) throw new Error('Failed to load gallery');
+    if (!res.ok) throw new Error("Failed to load gallery");
     return res.json();
   });
 };
@@ -95,11 +99,11 @@ export const uploadGalleryImage = async (src) => {
   if (useMock) return mockUploadGalleryImage(src);
   return withLoading(async () => {
     const res = await fetch(`${API_BASE}/api/gallery`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ src }),
     });
-    if (!res.ok) throw new Error('Failed to save image');
+    if (!res.ok) throw new Error("Failed to save image");
     return res.json();
   });
 };
@@ -107,8 +111,23 @@ export const uploadGalleryImage = async (src) => {
 export const deleteGalleryImage = async (id) => {
   if (useMock) return mockDeleteGalleryImage(id);
   return withLoading(async () => {
-    const res = await fetch(`${API_BASE}/api/gallery/${id}`, { method: 'DELETE' });
-    if (!res.ok) throw new Error('Failed to delete image');
+    const res = await fetch(`${API_BASE}/api/gallery/${id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) throw new Error("Failed to delete image");
+    return res.json();
+  });
+};
+
+export const subscribeNewsletter = async (email) => {
+  if (useMock) return mockSubscribeNewsletter(email);
+  return withLoading(async () => {
+    const res = await fetch(`${API_BASE}/api/newsletter`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+    if (!res.ok) throw new Error("Failed to subscribe");
     return res.json();
   });
 };

--- a/src/components/NewsletterSection.jsx
+++ b/src/components/NewsletterSection.jsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { useLanguage } from "./LanguageContext";
 import { FaPaperPlane } from "react-icons/fa";
 import { useToast } from "./ToastContext";
+import { subscribeNewsletter } from "../api";
 import heroImg from "../assets/img/newsletter.jpg";
 
 const Section = styled.section`
@@ -64,39 +65,50 @@ const Button = styled(motion.button)`
 `;
 
 const NewsletterSection = () => {
-  const [submitted, setSubmitted] = useState(false);
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
   const { t } = useLanguage();
   const { showToast } = useToast();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    setSubmitted(true);
-    showToast(t("newsletter.success"), "success");
-    setTimeout(() => setSubmitted(false), 2000);
+    setLoading(true);
+    try {
+      await subscribeNewsletter(email);
+      setEmail("");
+      showToast(t("newsletter.success"), "success");
+    } catch {
+      showToast(t("newsletter.error"), "error");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <Section>
       <Overlay />
       <Content className="container">
-          <h2>{t("newsletter.title")}</h2>
-          <p>{t("newsletter.subtitle")}</p>
-          <Form onSubmit={handleSubmit}>
-            <Input
-              type="email"
-              placeholder={t("newsletter.email")}
-              required
-              whileFocus={{ scale: 1.02 }}
-            />
-            <Button
-              type="submit"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              {t("newsletter.subscribe")} <FaPaperPlane />
-            </Button>
-          </Form>
-          {/* success handled via toast */}
+        <h2>{t("newsletter.title")}</h2>
+        <p>{t("newsletter.subtitle")}</p>
+        <Form onSubmit={handleSubmit}>
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder={t("newsletter.email")}
+            required
+            whileFocus={{ scale: 1.02 }}
+          />
+          <Button
+            type="submit"
+            disabled={loading}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            {t("newsletter.subscribe")} <FaPaperPlane />
+          </Button>
+        </Form>
+        {/* success handled via toast */}
       </Content>
     </Section>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,8 @@
     "subtitle": "Stay updated on exclusive events",
     "email": "Email",
     "subscribe": "Subscribe",
-    "success": "Thank you for subscribing!"
+    "success": "Thank you for subscribing!",
+    "error": "Subscription failed"
   },
   "events": {
     "title": "Next Events",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -19,7 +19,8 @@
     "subtitle": "Rimani aggiornato sugli eventi esclusivi",
     "email": "Email",
     "subscribe": "Iscriviti",
-    "success": "Grazie per la tua iscrizione!"
+    "success": "Grazie per la tua iscrizione!",
+    "error": "Errore durante l'iscrizione"
   },
   "events": {
     "title": "Prossimi Eventi",

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -1,133 +1,137 @@
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid } from "uuid";
 
 export let mockEvents = [
   {
-    id: '1',
-    name: 'Wan Seend',
-    dj: 'DJ Alpha',
-    place: 'Roma',
-    date: '2027-05-10',
-    time: '21:00',
-    price: '15',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "1",
+    name: "Wan Seend",
+    dj: "DJ Alpha",
+    place: "Roma",
+    date: "2027-05-10",
+    time: "21:00",
+    price: "15",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '2',
-    name: 'Night Beats',
-    dj: 'DJ Beta',
-    place: 'Milano',
-    date: '2027-06-15',
-    time: '22:30',
-    price: '18',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "2",
+    name: "Night Beats",
+    dj: "DJ Beta",
+    place: "Milano",
+    date: "2027-06-15",
+    time: "22:30",
+    price: "18",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '3',
-    name: 'Electro Wave',
-    dj: 'DJ Gamma',
-    place: 'Torino',
-    date: '2027-07-20',
-    time: '20:00',
-    price: '20',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "3",
+    name: "Electro Wave",
+    dj: "DJ Gamma",
+    place: "Torino",
+    date: "2027-07-20",
+    time: "20:00",
+    price: "20",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '4',
-    name: 'Bass Trip',
-    dj: 'DJ Delta',
-    place: 'Bologna',
-    date: '2027-08-05',
-    time: '23:00',
-    price: '22',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "4",
+    name: "Bass Trip",
+    dj: "DJ Delta",
+    place: "Bologna",
+    date: "2027-08-05",
+    time: "23:00",
+    price: "22",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '5',
-    name: 'Sunset Vibes',
-    dj: 'DJ Epsilon',
-    place: 'Napoli',
-    date: '2027-09-12',
-    time: '19:00',
-    price: '17',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "5",
+    name: "Sunset Vibes",
+    dj: "DJ Epsilon",
+    place: "Napoli",
+    date: "2027-09-12",
+    time: "19:00",
+    price: "17",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '6',
-    name: 'Moonlight Jam',
-    dj: 'DJ Zeta',
-    place: 'Firenze',
-    date: '2027-10-03',
-    time: '21:30',
-    price: '19',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "6",
+    name: "Moonlight Jam",
+    dj: "DJ Zeta",
+    place: "Firenze",
+    date: "2027-10-03",
+    time: "21:30",
+    price: "19",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '7',
-    name: 'Groove Town',
-    dj: 'DJ Eta',
-    place: 'Genova',
-    date: '2027-11-18',
-    time: '22:00',
-    price: '16',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "7",
+    name: "Groove Town",
+    dj: "DJ Eta",
+    place: "Genova",
+    date: "2027-11-18",
+    time: "22:00",
+    price: "16",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '8',
-    name: 'Rave City',
-    dj: 'DJ Theta',
-    place: 'Verona',
-    date: '2027-12-09',
-    time: '20:30',
-    price: '21',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
+    id: "8",
+    name: "Rave City",
+    dj: "DJ Theta",
+    place: "Verona",
+    date: "2027-12-09",
+    time: "20:30",
+    price: "21",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
   },
   {
-    id: '9',
-    name: 'Electro Fest',
-    dj: 'DJ Iota',
-    place: 'Bari',
-    date: '2028-01-14',
-    time: '22:00',
-    price: '24',
-    image: '',
-    description: 'Lorem ipsum dolor sit amet.'
-  }
+    id: "9",
+    name: "Electro Fest",
+    dj: "DJ Iota",
+    place: "Bari",
+    date: "2028-01-14",
+    time: "22:00",
+    price: "24",
+    image: "",
+    description: "Lorem ipsum dolor sit amet.",
+  },
 ];
 
 export let mockBookings = [
   {
-    id: '1',
-    nome: 'Mario',
-    cognome: 'Rossi',
-    email: 'mario@example.com',
-    telefono: '3331234567',
-    quantity: 1
-  }
+    id: "1",
+    nome: "Mario",
+    cognome: "Rossi",
+    email: "mario@example.com",
+    telefono: "3331234567",
+    quantity: 1,
+  },
 ];
 
 export let mockGallery = [];
+export let mockSubscribers = [];
 
 const save = () => {
-  localStorage.setItem('mockEvents', JSON.stringify(mockEvents));
-  localStorage.setItem('mockBookings', JSON.stringify(mockBookings));
-  localStorage.setItem('mockGallery', JSON.stringify(mockGallery));
+  localStorage.setItem("mockEvents", JSON.stringify(mockEvents));
+  localStorage.setItem("mockBookings", JSON.stringify(mockBookings));
+  localStorage.setItem("mockGallery", JSON.stringify(mockGallery));
+  localStorage.setItem("mockSubscribers", JSON.stringify(mockSubscribers));
 };
 
 export const loadMock = () => {
-  const e = localStorage.getItem('mockEvents');
+  const e = localStorage.getItem("mockEvents");
   if (e) mockEvents = JSON.parse(e);
-  const b = localStorage.getItem('mockBookings');
+  const b = localStorage.getItem("mockBookings");
   if (b) mockBookings = JSON.parse(b);
-  const g = localStorage.getItem('mockGallery');
+  const g = localStorage.getItem("mockGallery");
   if (g) mockGallery = JSON.parse(g);
+  const s = localStorage.getItem("mockSubscribers");
+  if (s) mockSubscribers = JSON.parse(s);
 };
 
 export const mockFetchEvents = async () => {
@@ -181,4 +185,12 @@ export const mockDeleteGalleryImage = async (id) => {
   mockGallery = mockGallery.filter((g) => g.id !== id);
   save();
   return { success: true };
+};
+
+export const mockSubscribeNewsletter = async (email) => {
+  loadMock();
+  const sub = { id: uuid(), email };
+  mockSubscribers.push(sub);
+  save();
+  return sub;
 };


### PR DESCRIPTION
## Summary
- handle newsletter signups via new Brevo API endpoint
- expose BREVO credentials in `.env.example`
- add API helper and component logic for subscribing
- localize newsletter error messages
- document Brevo env vars

## Testing
- `npm run build`
- `npm start` in `server`

------
https://chatgpt.com/codex/tasks/task_e_685abec9fe28832481c07b47f12d3de6