### PR TITLE
Handle missing Firebase API key to prevent auth error

### DIFF
--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -13,10 +13,16 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
+let app;
+let db;
+let auth;
+
 if (!firebaseConfig.apiKey) {
   console.warn("Firebase config missing. Check environment variables.");
+} else {
+  app = initializeApp(firebaseConfig);
+  db = getFirestore(app);
+  auth = getAuth(app);
 }
 
-const app = initializeApp(firebaseConfig);
-export const db = getFirestore(app);
-export const auth = getAuth(app);
+export { app, db, auth };


### PR DESCRIPTION
## Summary
- Guard Firebase initialization against missing API key
- Export uninitialized Firebase services when config is absent to avoid runtime errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a195614f5883248eda254e5015581c