### PR TITLE
Guard admin login when Firebase auth is unavailable

### DIFF
--- a/src/components/AdminLogin.jsx
+++ b/src/components/AdminLogin.jsx
@@ -15,6 +15,7 @@ const AdminLogin = () => {
   const { t } = useLanguage();
 
   useEffect(() => {
+    if (!auth) return; // Firebase non configurato
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       if (user) {
         localStorage.setItem('isAdmin', 'true');
@@ -27,6 +28,10 @@ const AdminLogin = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+    if (!auth) {
+      setError('Configurazione Firebase mancante');
+      return;
+    }
     try {
       await signInWithEmailAndPassword(auth, email, password);
       localStorage.setItem('isAdmin', 'true');


### PR DESCRIPTION
## Summary
- avoid calling Firebase auth functions when configuration is missing
- show error message if login attempted without Firebase auth

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a19717d06c8324b42b1e7b0c99ee0e