### PR TITLE
Use Firebase tokens for admin authentication

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,8 +11,6 @@
     "express": "^4.18.2",
     "cors": "^2.8.5",
     "firebase-admin": "^11.10.1",
-    "dotenv": "^16.3.1",
-    "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.2"
+    "dotenv": "^16.3.1"
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -16,23 +16,8 @@ const useMock = import.meta.env.VITE_MOCK !== "false";
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
 let authToken = null;
 
-export const login = async (password) => {
-  if (useMock) {
-    if (password === (import.meta.env.VITE_ADMIN_PASSWORD || "admin"))
-      return { success: true };
-    throw new Error("Invalid password");
-  }
-  return withLoading(async () => {
-    const res = await fetch(`${API_BASE}/api/login`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ password }),
-    });
-    if (!res.ok) throw new Error("Invalid password");
-    const data = await res.json();
-    authToken = data.token;
-    return data;
-  });
+export const setAuthToken = (token) => {
+  authToken = token;
 };
 
 export const fetchEvents = async () => {

--- a/src/components/AdminLogin.jsx
+++ b/src/components/AdminLogin.jsx
@@ -6,6 +6,7 @@ import { signInWithEmailAndPassword, onAuthStateChanged } from 'firebase/auth';
 import logo from '../assets/img/ADMIN.png';
 import heroImg from '../assets/img/hero.png';
 import { auth } from '../firebase/config';
+import { setAuthToken } from '../api';
 
 const AdminLogin = () => {
   const [email, setEmail] = useState('');
@@ -16,8 +17,10 @@ const AdminLogin = () => {
 
   useEffect(() => {
     if (!auth) return; // Firebase non configurato
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
+        const token = await user.getIdToken();
+        setAuthToken(token);
         localStorage.setItem('isAdmin', 'true');
         navigate('/admin/panel');
       }
@@ -34,6 +37,8 @@ const AdminLogin = () => {
     }
     try {
       await signInWithEmailAndPassword(auth, email, password);
+      const token = await auth.currentUser.getIdToken();
+      setAuthToken(token);
       localStorage.setItem('isAdmin', 'true');
       navigate('/admin/panel');
     } catch (err) {

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -9,6 +9,7 @@ import {
   fetchGallery,
   uploadGalleryImage,
   deleteGalleryImage,
+  setAuthToken,
 } from "../api";
 import { withLoading } from "../loading";
 import {
@@ -355,6 +356,7 @@ const AdminPanel = () => {
     } catch (err) {
       console.error(err);
     }
+    setAuthToken(null);
     localStorage.removeItem("isAdmin");
     navigate("/admin");
   };


### PR DESCRIPTION
## Summary
- Replace password-based admin login with Firebase token verification on the server
- Store Firebase ID tokens in the client and attach them to protected API requests
- Remove obsolete bcrypt and JWT dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm --prefix server test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a199d0ece483249c0f2d98cdde5f54