### PR TITLE
fix: guard firebase app initialization

### DIFF
--- a/src/firebase/config.js
+++ b/src/firebase/config.js
@@ -1,6 +1,6 @@
 // Firebase configuration and initialization
 // Replace the placeholders with your Firebase project credentials.
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApps, getApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 
@@ -20,7 +20,7 @@ let auth;
 if (!firebaseConfig.apiKey) {
   console.warn("Firebase config missing. Check environment variables.");
 } else {
-  app = initializeApp(firebaseConfig);
+  app = getApps().length ? getApp() : initializeApp(firebaseConfig);
   db = getFirestore(app);
   auth = getAuth(app);
 }


### PR DESCRIPTION
## Summary
- prevent duplicate Firebase initialization by reusing existing apps

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a19c41de788324b64156be6f0495fe