### PR TITLE
feat: allow Firebase env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ npm run server
 
 Create a `.env` file inside the `server` directory by copying `.env.example` and
 set your backend configuration values (e.g. `PORT`, `FIREBASE_SERVICE_ACCOUNT` or
-`GOOGLE_APPLICATION_CREDENTIALS`, and `FIREBASE_PROJECT_ID`) before starting the
-API server. To enable newsletter subscriptions via Brevo, configure also
+`GOOGLE_APPLICATION_CREDENTIALS`, and `FIREBASE_PROJECT_ID`). The server also
+accepts `VITE_FIREBASE_SERVICE_ACCOUNT` and `VITE_FIREBASE_PROJECT_ID` for
+compatibility with the frontend `.env` variables. Configure these before starting
+the API server. To enable newsletter subscriptions via Brevo, configure also
 `BREVO_API_KEY` and `BREVO_LIST_ID` with your account details.
 
 After configuring Firebase credentials you can create the required Firestore collections with:

--- a/server/firebase.js
+++ b/server/firebase.js
@@ -3,10 +3,13 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { readFileSync, existsSync } from 'fs';
 
 const serviceAccountPath =
-  process.env.FIREBASE_SERVICE_ACCOUNT || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  process.env.FIREBASE_SERVICE_ACCOUNT ||
+  process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+  process.env.VITE_FIREBASE_SERVICE_ACCOUNT;
 
 let credential;
-let projectId = process.env.FIREBASE_PROJECT_ID;
+let projectId =
+  process.env.FIREBASE_PROJECT_ID || process.env.VITE_FIREBASE_PROJECT_ID;
 
 if (serviceAccountPath && existsSync(serviceAccountPath)) {
   const serviceAccount = JSON.parse(readFileSync(serviceAccountPath, 'utf8'));


### PR DESCRIPTION
## Summary
- accept `VITE_FIREBASE_SERVICE_ACCOUNT` and `VITE_FIREBASE_PROJECT_ID` vars for backend configuration
- document backend env fallbacks for Firebase

## Testing
- `VITE_FIREBASE_PROJECT_ID=test-project node server/index.js >/tmp/server.log 2>&1 &`


------
https://chatgpt.com/codex/tasks/task_e_68a5799f42048324bad8c5be8b741b4f