### PR TITLE
Proxy API requests in Vite dev server to backend

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,11 @@ export default {
   server: {
     host: '0.0.0.0',
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
 };


### PR DESCRIPTION
## Summary
- forward `/api` calls to Express backend via Vite proxy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a580f783b0832499eb5c99b0fea4e8