### PR TITLE
Enable contact form email notifications

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1129,6 +1129,27 @@ async function brevoSubscribeHandler(req, res) {
 app.post("/api/newsletter", publicLimiter, brevoSubscribeHandler);
 app.post("/api/newsletter/subscribe", publicLimiter, brevoSubscribeHandler);
 
+// Contatti: invia email a staff
+app.post("/api/contact", publicLimiter, async (req, res) => {
+    const { name, email, message } = req.body || {};
+    if (!name || !email || !message) {
+        return res.status(400).json({ ok: false, error: "missing_fields" });
+    }
+    try {
+        await mailer.sendMail({
+            from: FROM_EMAIL,
+            to: process.env.CONTACT_EMAIL || "djscovery.channel@gmail.com",
+            replyTo: email,
+            subject: `Nuovo contatto dal sito - ${name}`,
+            text: `Nome: ${name}\nEmail: ${email}\n\n${message}`,
+        });
+        res.json({ ok: true });
+    } catch (err) {
+        console.error("Errore invio contatto:", err?.message || err);
+        res.status(500).json({ ok: false, error: "email_failed" });
+    }
+});
+
 /* ----------------- Health & Debug ----------------- */
 app.get("/healthz", (_req, res) => res.json({ ok: true }));
 app.get("/api/auth/whoami", authenticate, (req, res) => res.json({ user: req.user }));

--- a/src/api.js
+++ b/src/api.js
@@ -10,6 +10,7 @@ import {
     mockUploadGalleryImage,
     mockDeleteGalleryImage,
     mockSubscribeNewsletter,
+    mockSendContact,
 } from "./mockApi";
 import { withLoading } from "./loading";
 
@@ -221,6 +222,21 @@ export const deleteAllEvents = async (status=null) => {
 
 
 
+
+/* =======================
+   CONTACT
+   ======================= */
+export const sendContact = async (data) => {
+    if (useMock) return mockSendContact(data);
+    return withLoading(async () => {
+        const res = await fetch(`${API_BASE}/api/contact`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        });
+        return handleResponse(res);
+    });
+};
 
 /* =======================
    GALLERY

--- a/src/components/ContattiSection.jsx
+++ b/src/components/ContattiSection.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { motion } from "framer-motion";
 import { useLanguage } from "./LanguageContext";
+import { sendContact } from "../api";
 
 const Section = styled(motion.section)`
   text-align: center;
@@ -62,12 +63,24 @@ const Button = styled(motion.button)`
 
 const ContattiSection = () => {
   const [submitted, setSubmitted] = useState(false);
+  const [form, setForm] = useState({ name: "", email: "", message: "" });
   const { t } = useLanguage();
 
-  const handleSubmit = (e) => {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    setSubmitted(true);
-    setTimeout(() => setSubmitted(false), 2000);
+    try {
+      await sendContact(form);
+      setSubmitted(true);
+      setForm({ name: "", email: "", message: "" });
+      setTimeout(() => setSubmitted(false), 2000);
+    } catch (err) {
+      console.error("Errore invio contatto:", err);
+    }
   };
 
   return (
@@ -85,17 +98,26 @@ const ContattiSection = () => {
           <Input
             whileFocus={{ scale: 1.02 }}
             type="text"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
             placeholder={t("contacts.name")}
             required
           />
           <Input
             whileFocus={{ scale: 1.02 }}
             type="email"
+            name="email"
+            value={form.email}
+            onChange={handleChange}
             placeholder={t("contacts.email")}
             required
           />
           <TextArea
             whileFocus={{ scale: 1.02 }}
+            name="message"
+            value={form.message}
+            onChange={handleChange}
             placeholder={t("contacts.message")}
             rows="5"
             required

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -232,3 +232,8 @@ export const mockSubscribeNewsletter = async (email) => {
   save();
   return sub;
 };
+
+// mock contact form
+export const mockSendContact = async () => {
+  return { ok: true };
+};


### PR DESCRIPTION
## Summary
- send contact form submissions to djscovery.channel@gmail.com via new `/api/contact` endpoint
- expose `sendContact` API helper and integrate it into `ContattiSection`
- add mock handler for contact form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6a39ac4248324a8ee03e38e7be3b8