### PR TITLE
fix: add missing FormControl import

### DIFF
--- a/src/components/admin/CheckInBox.jsx
+++ b/src/components/admin/CheckInBox.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { Box, Button, IconButton, Stack, Typography, Switch, Dialog, DialogContent, FormHelperText, TextField, CircularProgress, useTheme, useMediaQuery } from "@mui/material";
+import { Box, Button, IconButton, Stack, Typography, Switch, Dialog, DialogContent, FormControl, FormHelperText, TextField, CircularProgress, useTheme, useMediaQuery } from "@mui/material";
 import QrCodeScannerIcon from "@mui/icons-material/QrCodeScanner";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import VolumeOffIcon from "@mui/icons-material/VolumeOff";


### PR DESCRIPTION
## Summary
- import missing FormControl component into CheckInBox to prevent runtime errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b82553c46c8324965c2d92fea9499c