### PR TITLE
Format dates and localize status labels

### DIFF
--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { useLanguage } from "./LanguageContext";
+import { formatDate } from "./admin/eventUtils";
 import {
     fetchBookings,
     createEvent,
@@ -174,6 +176,7 @@ const canEditEvent = (role) => role === roles.admin || role === roles.editor;
 /* --------------- MAIN --------------- */
 const AdminPanel = () => {
     const navigate = useNavigate();
+    const { t } = useLanguage();
     const { showToast } = useToast();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
@@ -607,7 +610,7 @@ const AdminPanel = () => {
         if (updates.length) {
             await Promise.all(updates);
             await refetchEvents();
-            showToast("Aggiornato stato Sold Out automaticamente", "info");
+            showToast(t("admin.toast.auto_soldout"), "info");
         }
     }, [events, bookings, showToast, refetchEvents]);
 
@@ -1106,7 +1109,7 @@ const AdminPanel = () => {
                                                 <TableCell>Ora</TableCell>
                                                 <TableCell>Capienza</TableCell>
                                                 <TableCell>Status</TableCell>
-                                                <TableCell>Sold Out</TableCell>
+                                                <TableCell>{t("admin.events.columns.soldOut")}</TableCell>
                                                 <TableCell align="right">Azioni</TableCell>
                                             </TableRow>
                                         </TableHead>
@@ -1135,13 +1138,13 @@ const AdminPanel = () => {
                                                         </TableCell>
                                                         <TableCell>{ev.dj || "—"}</TableCell>
                                                         <TableCell>{ev.place || "—"}</TableCell>
-                                                        <TableCell>{ev.date}</TableCell>
+                                                        <TableCell>{formatDate(ev.date)}</TableCell>
                                                         <TableCell>{ev.time}</TableCell>
                                                         <TableCell>{ev.capacity || "-"}</TableCell>
                                                         <TableCell>
                                                             <Chip
                                                                 size="small"
-                                                                label={status}
+                                                                label={t(`admin.events.statuses.${status}`)}
                                                                 color={
                                                                     status === "draft"
                                                                         ? "default"
@@ -1374,7 +1377,7 @@ const AdminPanel = () => {
                                                         disabled={formData.soldOut}           // ← visibile ma non editabile
                                                         inputProps={{ step: "0.5", min: "0" }}
                                                         error={!!errors.price}
-                                                        helperText={errors.price || (formData.soldOut ? "Sold out: il prezzo resta visibile" : "")}
+                                                        helperText={errors.price || (formData.soldOut ? t("admin.form.soldOut_hint") : "")}
                                                         InputProps={{
                                                             startAdornment: (
                                                                 <InputAdornment position="start">
@@ -1619,7 +1622,7 @@ const AdminPanel = () => {
                                                     </Typography>
                                                     <Stack spacing={1.5}>
                                                         <Stack direction="row" alignItems="center" spacing={1}>
-                                                            <Typography variant="body2">Sold out</Typography>
+                                                            <Typography variant="body2">{t("admin.form.soldOut")}</Typography>
                                                             <Switch
                                                                 checked={formData.soldOut}
                                                                 onChange={(_, checked) =>
@@ -1629,7 +1632,7 @@ const AdminPanel = () => {
                                                             />
                                                         </Stack>
                                                         <FormHelperText>
-                                                            Se attivo, il campo prezzo viene disabilitato.
+                                                            {t("admin.form.soldOut_hint")}
                                                         </FormHelperText>
                                                     </Stack>
                                                 </Paper>
@@ -1747,7 +1750,7 @@ const AdminPanel = () => {
                                             <MenuItem value="all">Tutti gli eventi</MenuItem>
                                             {events.map((ev) => (
                                                 <MenuItem key={ev.id} value={ev.id}>
-                                                    {ev.name} — {ev.date}
+                                                    {ev.name} — {formatDate(ev.date)}
                                                 </MenuItem>
                                             ))}
                                         </Select>

--- a/src/components/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy.jsx
@@ -46,7 +46,11 @@ const Card = styled(motion.div)`
 `;
 
 const PrivacyPolicy = () => {
-    const lastUpdate = new Date().toLocaleDateString("it-IT");
+    const lastUpdate = new Date().toLocaleDateString("it-IT", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+    });
 
     return (
         <Section>

--- a/src/components/admin/MobileEventCard.jsx
+++ b/src/components/admin/MobileEventCard.jsx
@@ -17,10 +17,12 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { isPast } from "./eventUtils";
+import { isPast, formatDate } from "./eventUtils";
+import { useLanguage } from "../LanguageContext";
 
 function MobileEventCard({ ev, onEdit, onDelete, onToggleSoldOut, onDuplicate, onExportICS, canDelete }) {
     const past = isPast(ev);
+    const { t } = useLanguage();
     const statusColor =
         ev.status === "draft" ? "default" : ev.status === "archived" ? "warning" : "success";
     return (
@@ -29,19 +31,19 @@ function MobileEventCard({ ev, onEdit, onDelete, onToggleSoldOut, onDuplicate, o
                 <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5, flexWrap: "wrap" }}>
                     {!past ? <CheckCircleIcon color="success" fontSize="small" /> : <LockClockIcon color="disabled" fontSize="small" />}
                     <Typography variant="subtitle1" fontWeight={700}>{ev.name}</Typography>
-                    <Chip size="small" label={ev.status || "published"} sx={{ ml: "auto" }} color={statusColor} />
+                    <Chip size="small" label={t(`admin.events.statuses.${ev.status || "published"}`)} sx={{ ml: "auto" }} color={statusColor} />
                 </Stack>
                 <Typography variant="body2" sx={{ opacity: 0.85 }}>{ev.dj || "—"}</Typography>
                 <Typography variant="body2" sx={{ opacity: 0.85 }}>{ev.place || "—"}</Typography>
                 <Stack direction="row" spacing={2} sx={{ mt: 1, opacity: 0.8 }}>
-                    <Typography variant="caption">📅 {ev.date}</Typography>
+                    <Typography variant="caption">📅 {formatDate(ev.date)}</Typography>
                     <Typography variant="caption">⏰ {ev.time}</Typography>
                     <Typography variant="caption">👥 {ev.capacity || "-"}</Typography>
                 </Stack>
             </CardContent>
             <CardActions sx={{ pt: 0, pb: 1.5, px: 2, justifyContent: "space-between" }}>
                 <Stack direction="row" spacing={1} alignItems="center">
-                    <Typography variant="caption">Sold Out</Typography>
+                    <Typography variant="caption">{t("admin.form.soldOut")}</Typography>
                     <Switch size="small" color="warning" checked={!!ev.soldOut} onChange={(e) => onToggleSoldOut(e.target.checked)} disabled={past} />
                 </Stack>
                 <Stack direction="row" spacing={1}>

--- a/src/components/admin/eventUtils.js
+++ b/src/components/admin/eventUtils.js
@@ -5,6 +5,13 @@ export const eventDateTime = (ev) => {
   return isNaN(dt.getTime()) ? null : dt;
 };
 
+export const formatDate = (iso) => {
+  if (!iso) return "";
+  const [y, m, d] = iso.split("-");
+  if (!y || !m || !d) return iso;
+  return `${d}/${m}/${y}`;
+};
+
 export const isPast = (ev) => {
   const dt = eventDateTime(ev);
   return dt ? dt.getTime() < Date.now() : false;

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -35,7 +35,7 @@
     "loading": "Caricamento eventi...",
     "none": "Nessun evento disponibile",
     "book_now": "Prenota ora",
-    "sold_out": "Sold out"
+      "sold_out": "Esaurito"
   },
   "about": {
     "title": "Chi Siamo",
@@ -123,7 +123,7 @@
         "ora": "Ora",
         "capienza": "Capienza",
         "status": "Status",
-        "soldOut": "Sold Out",
+        "soldOut": "Esaurito",
         "azioni": "Azioni"
       },
       "actions": {
@@ -167,7 +167,7 @@
       "place_suggestions": "Suggerimenti da OSM/Geoapify",
       "map_preview": "Anteprima posizione (OpenStreetMap)",
       "saleStatus": "Stato vendita",
-      "soldOut": "Sold out",
+      "soldOut": "Esaurito",
       "soldOut_hint": "Se attivo, il campo prezzo viene disabilitato.",
       "buttons": {
         "save": "Salva modifiche",
@@ -195,7 +195,7 @@
       "save_error": "Errore nel salvataggio",
       "deleted": "Evento eliminato",
       "error": "Errore",
-      "auto_soldout": "Aggiornato stato Sold Out automaticamente"
+      "auto_soldout": "Aggiornato stato Esaurito automaticamente"
     },
     "confirm": {
       "title": "Conferma",


### PR DESCRIPTION
## Summary
- format all displayed dates as dd/MM/yyyy
- translate event status and "Sold Out" labels into Italian

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8304f024c8324a9cdc43f26b91e1a