### PR TITLE
Localize admin panel titles to Italian

### DIFF
--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -805,11 +805,14 @@ const AdminPanel = () => {
         { key: "create", label: "Crea / Modifica Evento", icon: <AddCircleOutlineIcon /> },
         { key: "bookings", label: "Prenotazioni", icon: <ListAltIcon /> },
         { key: "checkin", label: "Check-in", icon: <QrCodeScannerIcon /> },
-        { key: "gallery", label: "Gallery", icon: <PhotoLibraryIcon /> },
+        { key: "gallery", label: "Galleria", icon: <PhotoLibraryIcon /> },
     ].filter((item) => {
         if (role === roles.staff) return item.key === "checkin" || item.key === "bookings";
         return true;
     });
+
+    const currentSectionLabel =
+        navItems.find((item) => item.key === section)?.label || "";
 
     const drawer = (
         <div>
@@ -911,9 +914,7 @@ const AdminPanel = () => {
                                     sx={{ height: 32 }}
                                 />
                                 <Typography variant="h6" noWrap>
-                                    {section === "create"
-                                        ? "Crea / Modifica Evento"
-                                        : section.charAt(0).toUpperCase() + section.slice(1)}
+                                    {currentSectionLabel}
                                 </Typography>
                             </Stack>
                             <Stack direction="row" spacing={1} sx={{ display: { xs: "none", md: "flex" } }}>
@@ -941,8 +942,8 @@ const AdminPanel = () => {
                                     </IconButton>
                                 </Tooltip>
                             )}
-                            <Tooltip title="Logout">
-                                <IconButton color="inherit" onClick={handleLogout} aria-label="Logout">
+                            <Tooltip title="Esci">
+                                <IconButton color="inherit" onClick={handleLogout} aria-label="Esci">
                                     <LogoutIcon />
                                 </IconButton>
                             </Tooltip>

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -78,7 +78,7 @@
       "create": "Crea / Modifica Evento",
       "bookings": "Prenotazioni",
       "checkin": "Check-in",
-      "gallery": "Gallery"
+      "gallery": "Galleria"
     },
     "common": {
       "open_menu": "Apri menu",
@@ -88,13 +88,13 @@
       "no_images": "Nessuna immagine trovata."
     },
     "header": {
-      "admin": "Admin",
+      "admin": "Amministrazione",
       "createEditEvent": "Crea / Modifica Evento",
       "futuri": "Futuri",
       "passati": "Passati",
       "prenotazioni": "Prenotazioni",
       "drive": "Apri cartella Drive",
-      "logout": "Logout"
+      "logout": "Esci"
     },
     "events": {
       "search": "Cerca per nome / DJ / luogo",


### PR DESCRIPTION
## Summary
- Show Italian titles in the admin panel header
- Translate navigation and logout strings to Italian

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b835261df8832484a1be2e95f9f3e8