### PR TITLE
Fix Vercel catch-all API routing

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -1,0 +1,8 @@
+// api/[...slug].js - catch-all Vercel serverless function
+// Using a non-optional catch-all ensures sub-routes like /api/bookings
+// resolve to the shared Express app in production (Vercel)
+const serverless = require("serverless-http");
+const app = require("./app");
+
+// Directly export the Express app without stripping the /api prefix
+module.exports = serverless(app);

--- a/api/[[...slug]].js
+++ b/api/[[...slug]].js
@@ -1,7 +1,0 @@
-// api/[[...slug]].js - catch-all Vercel serverless function
-const serverless = require("serverless-http");
-const app = require("./app");
-
-
-// Directly export the Express app without stripping the /api prefix
-module.exports = serverless(app);


### PR DESCRIPTION
## Summary
- fix serverless function catch-all so nested routes like /api/bookings resolve

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c493e2571c8324831a6dd7a25810c5