### PR TITLE
feat(api): add firestore-backed events and bookings endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # djscovery
+
+## API
+
+This project exposes an Express-based serverless API under `/api`.
+
+- `GET /api/events` – list events stored in Firestore.
+- `GET /api/bookings` – list bookings stored in Firestore. Supports `eventId` query parameter to filter by event.
+
+When Firestore credentials are missing the API responds with `missing_service_account` instead of returning an HTML error page.

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const admin = require('firebase-admin');
+
+let db = null;
+function getDb() {
+  if (db) return db;
+  if (!admin.apps.length) {
+    try {
+      const svcRaw = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+      if (!svcRaw) throw new Error('missing_service_account');
+      const svc = JSON.parse(svcRaw);
+      admin.initializeApp({ credential: admin.credential.cert(svc) });
+    } catch (e) {
+      const err = new Error('missing_service_account');
+      err.code = 'missing_service_account';
+      throw err;
+    }
+  }
+  db = admin.firestore();
+  return db;
+}
+
+const app = express();
+app.get('/', (_req, res) => res.json({ ok: true }));
+
+app.get('/events', async (req, res, next) => {
+  try {
+    const db = getDb();
+    const snap = await db.collection('events').get();
+    res.json(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+  } catch (e) {
+    next(e);
+  }
+});
+
+app.get('/bookings', async (req, res, next) => {
+  try {
+    const db = getDb();
+    let ref = db.collection('bookings').orderBy('createdAt', 'desc');
+    if (req.query.eventId) {
+      ref = ref.where('eventId', '==', String(req.query.eventId));
+    }
+    const snap = await ref.get();
+    res.json(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+  } catch (e) {
+    next(e);
+  }
+});
+
+app.use((err, req, res, _next) => {
+  console.error('[api] error', err);
+  if (err.code === 'missing_service_account') {
+    return res.status(500).json({ ok: false, error: 'missing_service_account' });
+  }
+  res.status(500).json({ ok: false, error: 'internal' });
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- add Express serverless API exposing `/api/events` and `/api/bookings`
- pull events and bookings from Firestore
- document API usage in README

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d9a4f1b8832488672af87f451c88