### PR TITLE
feat: add mock CRUD for events and bookings

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -6,6 +6,10 @@ import {
     mockCreateEvent,
     mockUpdateEvent,
     mockDeleteEvent,
+    mockUpdateBooking,
+    mockDeleteBooking,
+    mockDeleteAllBookings,
+    mockDeleteAllEvents,
     mockFetchGallery,
     mockUploadGalleryImage,
     mockDeleteGalleryImage,
@@ -201,6 +205,7 @@ export const undoCheckIn = async (token, count = 1) => {
 
 // BOOKINGS admin
 export const updateBooking = async (id, data) => {
+    if (useMock) return mockUpdateBooking(id, data);
     const res = await fetch(`${API_BASE}/api/bookings/${id}`, {
         method: "PUT",
         headers: authHeaders({ "Content-Type": "application/json" }),
@@ -210,6 +215,7 @@ export const updateBooking = async (id, data) => {
 };
 
 export const deleteBooking = async (id) => {
+    if (useMock) return mockDeleteBooking(id);
     const res = await fetch(`${API_BASE}/api/bookings/${id}`, {
         method: "DELETE",
         headers: authHeaders(),
@@ -218,6 +224,7 @@ export const deleteBooking = async (id) => {
 };
 
 export const deleteAllBookings = async (eventId=null) => {
+    if (useMock) return mockDeleteAllBookings(eventId);
     const url = new URL(`${API_BASE}/api/bookings`);
     if (eventId) url.searchParams.set("eventId", eventId);
     const res = await fetch(url.toString(), {
@@ -229,6 +236,7 @@ export const deleteAllBookings = async (eventId=null) => {
 
 // EVENTS bulk
 export const deleteAllEvents = async (status=null) => {
+    if (useMock) return mockDeleteAllEvents(status);
     const url = new URL(`${API_BASE}/api/events`);
     if (status) url.searchParams.set("status", status);
     const res = await fetch(url.toString(), {

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -185,6 +185,21 @@ export const mockDeleteEvent = async (id) => {
   return { success: true };
 };
 
+export const mockDeleteAllEvents = async (status = null) => {
+  loadMock();
+  let deleted = 0;
+  if (status) {
+    const toKeep = mockEvents.filter((e) => (e.status || "") !== status);
+    deleted = mockEvents.length - toKeep.length;
+    mockEvents = toKeep;
+  } else {
+    deleted = mockEvents.length;
+    mockEvents = [];
+  }
+  save();
+  return { success: true, deleted };
+};
+
 export const mockSendBooking = async (data) => {
   loadMock();
   const newBooking = { id: uuid(), ...data };
@@ -203,6 +218,35 @@ export const mockSendBooking = async (data) => {
   }
   save();
   return newBooking;
+};
+
+export const mockUpdateBooking = async (id, data) => {
+  loadMock();
+  mockBookings = mockBookings.map((b) => (b.id === id ? { ...b, ...data } : b));
+  save();
+  return { success: true };
+};
+
+export const mockDeleteBooking = async (id) => {
+  loadMock();
+  mockBookings = mockBookings.filter((b) => b.id !== id);
+  save();
+  return { success: true };
+};
+
+export const mockDeleteAllBookings = async (eventId = null) => {
+  loadMock();
+  let deleted = 0;
+  if (eventId) {
+    const toKeep = mockBookings.filter((b) => b.eventId !== eventId);
+    deleted = mockBookings.length - toKeep.length;
+    mockBookings = toKeep;
+  } else {
+    deleted = mockBookings.length;
+    mockBookings = [];
+  }
+  save();
+  return { success: true, deleted };
 };
 
 export const mockFetchGallery = async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" },
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }
   ]


### PR DESCRIPTION
## Summary
- implement mock delete-all for events and bookings
- support mock update/delete for bookings
- wire mock CRUD into API layer
- ensure Vercel routes /api requests before SPA fallback so POST/PUT/DELETE work

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c56712ae588324b83c6d338448dc6e