### PR TITLE
Handle CORS preflight for CRUD requests

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -141,14 +141,17 @@ app.use((req, res, next) => {
 });
 
 // CORS: allow same-origin and common methods/headers (no wildcard path for Express 5)
-app.use(
-  cors({
-    origin: true,
-    credentials: true,
-    methods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization"],
-  })
-);
+const corsOptions = {
+  origin: true,
+  credentials: true,
+  methods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+};
+app.use(cors(corsOptions));
+// Handle preflight requests gracefully
+app.use((req, res, next) => {
+  if (req.method === "OPTIONS") return res.sendStatus(204);
+  next();
+});
 
 // Basic hardening
 app.use(helmet({ crossOriginResourcePolicy: { policy: "cross-origin" } }));


### PR DESCRIPTION
## Summary
- fix 405 errors by responding to OPTIONS after CORS middleware

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c688f871a48324b87939534f9d3a1c