### PR TITLE
Adjust mobile event cards and badge opacity

### DIFF
--- a/src/components/timed-cards-lite.css
+++ b/src/components/timed-cards-lite.css
@@ -42,18 +42,18 @@
 .tc-details .tc-meta .meta-item{
   padding:6px 10px;
   border-radius:12px;
-  background:rgba(255,255,255,.12);
+  background:rgba(255,255,255,.22);
   color:#fff;
   font-weight:600;
   font-size:12px;
   letter-spacing:.3px;
-  border:1px solid rgba(255,255,255,.20);
+  border:1px solid rgba(255,255,255,.35);
   box-shadow: 0 2px 6px rgba(0,0,0,.25);
 }
 .tc-details .tc-meta .meta-item.price{
-  background:rgba(236,173,41,.22);
+  background:rgba(236,173,41,.32);
   color:#fff;
-  border:1px solid rgba(236,173,41,.55);
+  border:1px solid rgba(236,173,41,.65);
   text-shadow: 0 1px 0 rgba(0,0,0,.20);
 }
 .tc-details .cta{ display:flex; gap:12px; margin-top:24px; }
@@ -128,10 +128,10 @@
   .tc-thumb{ flex:0 0 220px; }
 }
 @media (max-width: 768px){
-  .tc-root{ height:100svh; --picker-h: 180px; }
+  .tc-root{ height:100svh; --picker-h: 160px; }
   .tc-card{ background-position:center 40%; }
   .tc-details{ position:absolute; left:16px; top:36px; width:calc(100% - 32px); z-index:90; padding-right:6px; max-height:none; }
-  .tc-details-content{ padding-right:4px; max-height:calc(100svh - var(--picker-h) - 200px); }
+  .tc-details-content{ padding-right:4px; max-height:calc(100svh - var(--picker-h) - 180px); }
   .tc-details-content{ mask-image:none; -webkit-mask-image:none; }
   .tc-details-content::after{ display:none; }
   .tc-details .title-1, .tc-details .title-2{ font-size:clamp(26px, calc(6vw + 0.4rem), 38px); line-height:1.1; }


### PR DESCRIPTION
## Summary
- reduce the mobile picker height so more description text is visible in the events carousel
- increase the opacity of time/date/price badges to improve legibility on top of imagery

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9a0d2d2483249f635b098a82d839