### PR TITLE
Improve analytics dashboard responsiveness

### DIFF
--- a/src/components/admin/AnalyticsDashboard.jsx
+++ b/src/components/admin/AnalyticsDashboard.jsx
@@ -3,10 +3,10 @@ import {
   Box,
   Button,
   Chip,
-  Grid,
   Paper,
   Stack,
   Typography,
+  useMediaQuery,
   useTheme,
 } from "@mui/material";
 import RefreshIcon from "@mui/icons-material/Refresh";
@@ -68,6 +68,7 @@ const AnalyticsDashboard = ({
   isFetchingEvents,
 }) => {
   const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   const totalTickets = useMemo(
     () => bookings.reduce((sum, booking) => sum + quantityFromBooking(booking), 0),
@@ -260,91 +261,229 @@ const AnalyticsDashboard = ({
             startIcon={<RefreshIcon />}
             onClick={onRefresh}
             disabled={isRefreshing}
+            fullWidth={isSmallScreen}
+            sx={{ alignSelf: { xs: "stretch", md: "center" } }}
           >
             {isRefreshing ? "Aggiornamento…" : "Aggiorna ora"}
           </Button>
         </Stack>
 
-        <Grid container spacing={2} sx={{ mt: 2 }}>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ ...glass, p: 2 }}>
-              <Stack spacing={0.5}>
-                <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                  Biglietti totali
-                </Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                  {totalTickets}
-                </Typography>
-                <Chip
-                  label={`${uniqueBookings} prenotazioni`}
-                  size="small"
-                  sx={{
-                    alignSelf: "flex-start",
-                    backgroundColor: "rgba(255,213,79,0.12)",
-                    color: "#FFD54F",
-                    border: "1px solid rgba(255,213,79,0.35)",
-                  }}
-                />
-              </Stack>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ ...glass, p: 2 }}>
-              <Stack spacing={0.5}>
-                <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                  Biglietti odierni
-                </Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                  {todayTickets}
-                </Typography>
-                <Typography variant="caption" sx={{ opacity: 0.6 }}>
-                  Generati il {todayKey.split("-").reverse().join("/")}
-                </Typography>
-              </Stack>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ ...glass, p: 2 }}>
-              <Stack spacing={0.5}>
-                <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                  Eventi futuri attivi
-                </Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                  {upcomingEventsCount}
-                </Typography>
-                <Typography variant="caption" sx={{ opacity: 0.6 }}>
-                  Include eventi pubblicati e da annunciare
-                </Typography>
-              </Stack>
-            </Paper>
-          </Grid>
-          <Grid item xs={12} sm={6} md={3}>
-            <Paper sx={{ ...glass, p: 2 }}>
-              <Stack spacing={0.5}>
-                <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                  Eventi sold out
-                </Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                  {soldOutEvents}
-                </Typography>
-                <Typography variant="caption" sx={{ opacity: 0.6 }}>
-                  Aggiornamento automatico
-                </Typography>
-              </Stack>
-            </Paper>
-          </Grid>
-        </Grid>
+        <Box
+          sx={{
+            mt: 2,
+            display: "grid",
+            gap: { xs: 2, md: 2.5 },
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, minmax(0, 1fr))",
+              md: "repeat(4, minmax(0, 1fr))",
+            },
+          }}
+        >
+          <Paper sx={{ ...glass, p: { xs: 2, md: 3 } }}>
+            <Stack spacing={0.5}>
+              <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                Biglietti totali
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                {totalTickets}
+              </Typography>
+              <Chip
+                label={`${uniqueBookings} prenotazioni`}
+                size="small"
+                sx={{
+                  alignSelf: "flex-start",
+                  backgroundColor: "rgba(255,213,79,0.12)",
+                  color: "#FFD54F",
+                  border: "1px solid rgba(255,213,79,0.35)",
+                }}
+              />
+            </Stack>
+          </Paper>
+          <Paper sx={{ ...glass, p: { xs: 2, md: 3 } }}>
+            <Stack spacing={0.5}>
+              <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                Biglietti odierni
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                {todayTickets}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.6 }}>
+                Generati il {todayKey.split("-").reverse().join("/")}
+              </Typography>
+            </Stack>
+          </Paper>
+          <Paper sx={{ ...glass, p: { xs: 2, md: 3 } }}>
+            <Stack spacing={0.5}>
+              <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                Eventi futuri attivi
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                {upcomingEventsCount}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.6 }}>
+                Include eventi pubblicati e da annunciare
+              </Typography>
+            </Stack>
+          </Paper>
+          <Paper sx={{ ...glass, p: { xs: 2, md: 3 } }}>
+            <Stack spacing={0.5}>
+              <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                Eventi sold out
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                {soldOutEvents}
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.6 }}>
+                Aggiornamento automatico
+              </Typography>
+            </Stack>
+          </Paper>
+        </Box>
       </Paper>
 
-      <Grid container spacing={3}>
-        <Grid item xs={12} md={8}>
-          <Paper sx={{ ...glass, p: 3, height: "100%" }}>
-            <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-              Andamento prenotazioni (ultimi 14 giorni)
-            </Typography>
-            <Box sx={{ height: 320 }}>
+      <Box
+        sx={{
+          display: "grid",
+          gap: { xs: 2, md: 3 },
+          gridTemplateColumns: {
+            xs: "1fr",
+            md: "repeat(12, minmax(0, 1fr))",
+          },
+        }}
+      >
+        <Paper
+          sx={{
+            ...glass,
+            p: { xs: 2, md: 3 },
+            height: "100%",
+            gridColumn: { xs: "1 / -1", md: "span 8" },
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+            Andamento prenotazioni (ultimi 14 giorni)
+          </Typography>
+          <Box sx={{ height: { xs: 260, sm: 320 } }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={bookingsTrend}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                <XAxis
+                  dataKey="label"
+                  stroke="rgba(255,255,255,0.6)"
+                  tickLine={false}
+                  axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
+                />
+                <YAxis
+                  stroke="rgba(255,255,255,0.6)"
+                  tickLine={false}
+                  axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
+                  allowDecimals={false}
+                />
+                <RechartsTooltip
+                  contentStyle={{
+                    backgroundColor: theme.palette.background.paper,
+                    borderRadius: 12,
+                    border: "1px solid rgba(255,255,255,0.1)",
+                  }}
+                  labelFormatter={(label) => `Giorno: ${label}`}
+                  formatter={(value) => [`${value} biglietti`, "Totale"]}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  stroke="#FFD54F"
+                  strokeWidth={3}
+                  dot={{ r: 4, stroke: "#FFD54F", strokeWidth: 2 }}
+                  activeDot={{ r: 6 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </Box>
+        </Paper>
+        <Paper
+          sx={{
+            ...glass,
+            p: { xs: 2, md: 3 },
+            height: "100%",
+            gridColumn: { xs: "1 / -1", md: "span 4" },
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+            Stato eventi
+          </Typography>
+          {eventsStatus.length === 0 ? (
+            <Box
+              sx={{
+                height: { xs: 220, sm: 260 },
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: 0.6,
+                textAlign: "center",
+              }}
+            >
+              Nessun evento disponibile per le statistiche.
+            </Box>
+          ) : (
+            <Box sx={{ height: { xs: 220, sm: 260 } }}>
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={bookingsTrend}>
+                <PieChart>
+                  <Pie
+                    data={eventsStatus}
+                    dataKey="value"
+                    nameKey="label"
+                    innerRadius={60}
+                    outerRadius={90}
+                    paddingAngle={4}
+                  >
+                    {eventsStatus.map((entry, index) => (
+                      <Cell
+                        key={entry.status}
+                        fill={COLORS[index % COLORS.length]}
+                      />
+                    ))}
+                  </Pie>
+                  <RechartsTooltip
+                    contentStyle={{
+                      backgroundColor: theme.palette.background.paper,
+                      borderRadius: 12,
+                      border: "1px solid rgba(255,255,255,0.1)",
+                    }}
+                    formatter={(value, name) => [`${value} eventi`, name]}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </Box>
+          )}
+        </Paper>
+        <Paper
+          sx={{
+            ...glass,
+            p: { xs: 2, md: 3 },
+            height: "100%",
+            gridColumn: { xs: "1 / -1", md: "span 6" },
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+            Eventi programmati per mese
+          </Typography>
+          {eventsByMonth.length === 0 ? (
+            <Box
+              sx={{
+                height: { xs: 220, sm: 260 },
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: 0.6,
+                textAlign: "center",
+              }}
+            >
+              Nessun evento programmato con data.
+            </Box>
+          ) : (
+            <Box sx={{ height: { xs: 220, sm: 260 } }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={eventsByMonth}>
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
                   <XAxis
                     dataKey="label"
@@ -364,177 +503,73 @@ const AnalyticsDashboard = ({
                       borderRadius: 12,
                       border: "1px solid rgba(255,255,255,0.1)",
                     }}
-                    labelFormatter={(label) => `Giorno: ${label}`}
-                    formatter={(value) => [`${value} biglietti`, "Totale"]}
+                    formatter={(value) => [`${value} eventi`, "Totale"]}
                   />
-                  <Line
-                    type="monotone"
-                    dataKey="value"
-                    stroke="#FFD54F"
-                    strokeWidth={3}
-                    dot={{ r: 4, stroke: "#FFD54F", strokeWidth: 2 }}
-                    activeDot={{ r: 6 }}
-                  />
-                </LineChart>
+                  <Bar dataKey="value" radius={[8, 8, 0, 0]} fill="#7986CB" />
+                </BarChart>
               </ResponsiveContainer>
             </Box>
-          </Paper>
-        </Grid>
-        <Grid item xs={12} md={4}>
-          <Paper sx={{ ...glass, p: 3, height: "100%" }}>
-            <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-              Stato eventi
-            </Typography>
-            {eventsStatus.length === 0 ? (
-              <Box
-                sx={{
-                  height: 260,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  opacity: 0.6,
-                  textAlign: "center",
-                }}
-              >
-                Nessun evento disponibile per le statistiche.
-              </Box>
-            ) : (
-              <Box sx={{ height: 260 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <PieChart>
-                    <Pie
-                      data={eventsStatus}
-                      dataKey="value"
-                      nameKey="label"
-                      innerRadius={60}
-                      outerRadius={90}
-                      paddingAngle={4}
-                    >
-                      {eventsStatus.map((entry, index) => (
-                        <Cell
-                          key={entry.status}
-                          fill={COLORS[index % COLORS.length]}
-                        />
-                      ))}
-                    </Pie>
-                    <RechartsTooltip
-                      contentStyle={{
-                        backgroundColor: theme.palette.background.paper,
-                        borderRadius: 12,
-                        border: "1px solid rgba(255,255,255,0.1)",
-                      }}
-                      formatter={(value, name) => [`${value} eventi`, name]}
-                    />
-                  </PieChart>
-                </ResponsiveContainer>
-              </Box>
-            )}
-          </Paper>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <Paper sx={{ ...glass, p: 3, height: "100%" }}>
-            <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-              Eventi programmati per mese
-            </Typography>
-            {eventsByMonth.length === 0 ? (
-              <Box
-                sx={{
-                  height: 260,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  opacity: 0.6,
-                  textAlign: "center",
-                }}
-              >
-                Nessun evento programmato con data.
-              </Box>
-            ) : (
-              <Box sx={{ height: 260 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={eventsByMonth}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
-                    <XAxis
-                      dataKey="label"
-                      stroke="rgba(255,255,255,0.6)"
-                      tickLine={false}
-                      axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
-                    />
-                    <YAxis
-                      stroke="rgba(255,255,255,0.6)"
-                      tickLine={false}
-                      axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
-                      allowDecimals={false}
-                    />
-                    <RechartsTooltip
-                      contentStyle={{
-                        backgroundColor: theme.palette.background.paper,
-                        borderRadius: 12,
-                        border: "1px solid rgba(255,255,255,0.1)",
-                      }}
-                      formatter={(value) => [`${value} eventi`, "Totale"]}
-                    />
-                    <Bar dataKey="value" radius={[8, 8, 0, 0]} fill="#7986CB" />
-                  </BarChart>
-                </ResponsiveContainer>
-              </Box>
-            )}
-          </Paper>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <Paper sx={{ ...glass, p: 3, height: "100%" }}>
-            <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-              Top eventi per prenotazioni
-            </Typography>
-            {topEvents.length === 0 ? (
-              <Box
-                sx={{
-                  height: 260,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  opacity: 0.6,
-                  textAlign: "center",
-                }}
-              >
-                Nessuna prenotazione registrata al momento.
-              </Box>
-            ) : (
-              <Box sx={{ height: 260 }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={topEvents}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
-                    <XAxis
-                      dataKey="name"
-                      stroke="rgba(255,255,255,0.6)"
-                      tickLine={false}
-                      axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
-                      interval={0}
-                      angle={-20}
-                      textAnchor="end"
-                    />
-                    <YAxis
-                      stroke="rgba(255,255,255,0.6)"
-                      tickLine={false}
-                      axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
-                      allowDecimals={false}
-                    />
-                    <RechartsTooltip
-                      contentStyle={{
-                        backgroundColor: theme.palette.background.paper,
-                        borderRadius: 12,
-                        border: "1px solid rgba(255,255,255,0.1)",
-                      }}
-                      formatter={(value) => [`${value} biglietti`, "Totale"]}
-                    />
-                    <Bar dataKey="value" radius={[8, 8, 0, 0]} fill="#4DB6AC" />
-                  </BarChart>
-                </ResponsiveContainer>
-              </Box>
-            )}
-          </Paper>
-        </Grid>
-      </Grid>
+          )}
+        </Paper>
+        <Paper
+          sx={{
+            ...glass,
+            p: { xs: 2, md: 3 },
+            height: "100%",
+            gridColumn: { xs: "1 / -1", md: "span 6" },
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+            Top eventi per prenotazioni
+          </Typography>
+          {topEvents.length === 0 ? (
+            <Box
+              sx={{
+                height: { xs: 220, sm: 260 },
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: 0.6,
+                textAlign: "center",
+              }}
+            >
+              Nessuna prenotazione registrata al momento.
+            </Box>
+          ) : (
+            <Box sx={{ height: { xs: 220, sm: 260 } }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={topEvents}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
+                  <XAxis
+                    dataKey="name"
+                    stroke="rgba(255,255,255,0.6)"
+                    tickLine={false}
+                    axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
+                    interval={0}
+                    angle={-20}
+                    textAnchor="end"
+                  />
+                  <YAxis
+                    stroke="rgba(255,255,255,0.6)"
+                    tickLine={false}
+                    axisLine={{ stroke: "rgba(255,255,255,0.2)" }}
+                    allowDecimals={false}
+                  />
+                  <RechartsTooltip
+                    contentStyle={{
+                      backgroundColor: theme.palette.background.paper,
+                      borderRadius: 12,
+                      border: "1px solid rgba(255,255,255,0.1)",
+                    }}
+                    formatter={(value) => [`${value} biglietti`, "Totale"]}
+                  />
+                  <Bar dataKey="value" radius={[8, 8, 0, 0]} fill="#4DB6AC" />
+                </BarChart>
+              </ResponsiveContainer>
+            </Box>
+          )}
+        </Paper>
+      </Box>
     </Stack>
   );
 };


### PR DESCRIPTION
## Summary
- adjust analytics dashboard layout to use CSS grid blocks for metrics and charts that scale from mobile to desktop widths
- add small-screen detection to stretch the refresh action and tune padding/heights for better handheld ergonomics
- preserve existing chart behaviour while preventing horizontal overflow on narrow viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceeba036a083249ffe4e552e77e702